### PR TITLE
Expose "ready" property for checking if server installed successfully

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.mypy_cache


### PR DESCRIPTION
The idea is to then have a check like this one in `def config`  in LSP-* packages:
```py
        if not server.ready:
            return read_client_config(self.name, {
                'enabled': False,
                'languages': [{}],
            })
```