### PR TITLE
Compare the file contents of each file, withouth parsing it to JSON

### DIFF
--- a/st3/lsp_utils/server_npm_resource.py
+++ b/st3/lsp_utils/server_npm_resource.py
@@ -1,4 +1,3 @@
-import json
 import os
 import shutil
 import sublime
@@ -78,10 +77,10 @@ class ServerNpmResource(object):
         if os.path.isdir(cache_server_path):
             # Server already in cache. Check if version has changed and if so, delete existing copy in cache.
             try:
-                src_package_json = json.loads(ResourcePath(src_path, 'package.json').read_text())
-                dst_package_json = json.loads(ResourcePath(dst_path, 'package.json').read_text())
+                src_package_json = ResourcePath(src_path, 'package.json').read_text()
+                dst_package_json = ResourcePath(dst_path, 'package.json').read_text()
 
-                if src_package_json['version'] != dst_package_json['version']:
+                if src_package_json != dst_package_json:
                     shutil.rmtree(cache_server_path)
             except FileNotFoundError:
                 shutil.rmtree(cache_server_path)


### PR DESCRIPTION
Just compare the file contents of each file, and if they don't match remove the folder.

I think comparing string is more performant
than parsing it to json and then comparing the versions.


This means that we delete the version from the package.json file.
```diff
{
  "name": "typescript-language-server",
-  "version": "0.4.0",
  "dependencies": {
    "typescript": "3.8.3",
    "typescript-language-server": "0.4.0"
  }
}
```
