### PR TITLE
Create NpmClientHandler to simplify NPM handler creation

### DIFF
--- a/st3/lsp_utils/__init__.py
+++ b/st3/lsp_utils/__init__.py
@@ -1,1 +1,2 @@
+from .npm_client_handler import NpmClientHandler
 from .server_npm_resource import ServerNpmResource

--- a/st3/lsp_utils/npm_client_handler.py
+++ b/st3/lsp_utils/npm_client_handler.py
@@ -1,0 +1,126 @@
+import shutil
+import sublime
+
+from LSP.plugin.core.handlers import LanguageHandler
+from LSP.plugin.core.settings import ClientConfig, read_client_config
+from LSP.plugin.core.typing import Dict
+from .server_npm_resource import ServerNpmResource
+
+CLIENT_SETTING_KEYS = ['env', 'experimental_capabilities', 'languages', 'initializationOptions', 'settings']
+
+
+class NpmClientHandler(LanguageHandler):
+    # To be overridden by subclass.
+    PACKAGE_NAME = None
+    SERVER_DIRECTORY = None
+    SERVER_BINARY_PATH = None
+    # Internal
+    __SERVER = None
+
+    def __init__(self):
+        super().__init__()
+        assert self.PACKAGE_NAME
+        self.package_name = self.PACKAGE_NAME
+        self.settings_filename = '{}.sublime-settings'.format(self.package_name)
+
+        # Calling setup() also here as this might run before `plugin_loaded`.
+        # Will be a no-op if already ran.
+        # See https://github.com/sublimelsp/LSP/issues/899
+        self.setup()
+
+    @classmethod
+    def setup(cls) -> None:
+        assert cls.PACKAGE_NAME
+        assert cls.SERVER_DIRECTORY
+        assert cls.SERVER_BINARY_PATH
+        if not cls.__SERVER:
+            cls.__SERVER = ServerNpmResource(cls.PACKAGE_NAME, cls.SERVER_DIRECTORY, cls.SERVER_BINARY_PATH)
+        cls.__SERVER.setup()
+
+    @classmethod
+    def cleanup(cls) -> None:
+        if cls.__SERVER:
+            cls.__SERVER.cleanup()
+
+    @property
+    def name(self) -> str:
+        return self.package_name.lower()
+
+    @property
+    def config(self) -> ClientConfig:
+        assert self.__SERVER
+
+        configuration = {
+            'enabled': True,
+            'command': ['node', self.__SERVER.binary_path] + self.get_binary_arguments(),
+        }
+
+        configuration.update(self._read_configuration())
+        self.on_client_configuration_ready(configuration)
+        return read_client_config(self.name, configuration)
+
+    def get_binary_arguments(self):
+        """
+        Returns a list of extra arguments to append when starting server.
+        """
+        return ['--stdio']
+
+    def _read_configuration(self) -> Dict:
+        settings = {}  # type: Dict
+        loaded_settings = sublime.load_settings(self.settings_filename)  # type: Dict
+
+        if loaded_settings:
+            migrated = self._migrate_obsolete_settings(settings)
+            changed = self.on_settings_read(loaded_settings)
+            if migrated or changed:
+                sublime.save_settings(self.settings_filename)
+
+            for key in CLIENT_SETTING_KEYS:
+                settings[key] = loaded_settings.get(key)
+
+        return settings
+
+    def on_settings_read(self, settings: Dict):
+        """
+        Called when package settings were read. Receives a `sublime.Settings` object.
+
+        Can be used to change user settings, migrating them to new schema, for example.
+
+        Return True if settings were modified to save changes to file.
+        """
+        return False
+
+    def _migrate_obsolete_settings(self, settings: Dict):
+        """
+        Migrates setting with a root `client` key to flattened structure.
+
+        Returns True if settings were migrated.
+        """
+        client = settings.get('client')  # type: Dict
+        if client:
+            settings.erase('client')
+            # Migrate old keys
+            for key, value in client.items():
+                settings.set(key, value)
+            return True
+        return False
+
+    def on_client_configuration_ready(self, configuration: Dict):
+        """
+        Called with default configuration object that contains merged default and user settings.
+
+        Can be used to alter default configuration before registering it.
+        """
+        pass
+
+    def on_start(self, window) -> bool:
+        if not self._is_node_installed():
+            sublime.status_message("{}: Please install Node.js for the server to work.".format(self.package_name))
+            return False
+        return self.server.ready
+
+    def on_initialized(self, client) -> None:
+        pass
+
+    def _is_node_installed(self):
+        return shutil.which('node') is not None

--- a/st3/lsp_utils/npm_client_handler.py
+++ b/st3/lsp_utils/npm_client_handler.py
@@ -25,9 +25,13 @@ class ApiWrapper(object):
         self.__client.on_notification(method, handler)
 
     def on_request(self, method: str, handler: Callable) -> None:
-        self.__client.on_request(
-            method,
-            lambda params, request_id: self.__client.send_response(Response(request_id, handler(params))))
+        def on_response(params, request_id):
+            handler(params, lambda result: send_response(request_id, result))
+
+        def send_response(request_id, result):
+            self.__client.send_response(Response(request_id, result))
+
+        self.__client.on_request(method, on_response)
 
 
 class NpmClientHandler(LanguageHandler):

--- a/st3/lsp_utils/npm_client_handler.py
+++ b/st3/lsp_utils/npm_client_handler.py
@@ -7,7 +7,14 @@ from LSP.plugin.core.settings import ClientConfig, read_client_config
 from LSP.plugin.core.typing import Callable, Dict
 from .server_npm_resource import ServerNpmResource
 
-CLIENT_SETTING_KEYS = ['env', 'experimental_capabilities', 'languages', 'initializationOptions', 'settings']
+# Keys to read and their fallbacks.
+CLIENT_SETTING_KEYS = {
+    'env': {},
+    'experimental_capabilities': {},
+    'languages': [],
+    'initializationOptions': {},
+    'settings': {},
+}  # type: ignore
 
 
 class ApiWrapper(object):
@@ -34,9 +41,7 @@ class NpmClientHandler(LanguageHandler):
     def __init__(self):
         super().__init__()
         assert self.package_name
-        self.package_name = self.package_name
         self.settings_filename = '{}.sublime-settings'.format(self.package_name)
-
         # Calling setup() also here as this might run before `plugin_loaded`.
         # Will be a no-op if already ran.
         # See https://github.com/sublimelsp/LSP/issues/899
@@ -89,8 +94,8 @@ class NpmClientHandler(LanguageHandler):
             if migrated or changed:
                 sublime.save_settings(self.settings_filename)
 
-            for key in CLIENT_SETTING_KEYS:
-                settings[key] = loaded_settings.get(key)
+            for key, default in CLIENT_SETTING_KEYS.items():
+                settings[key] = loaded_settings.get(key, default)
 
         return settings
 
@@ -137,9 +142,9 @@ class NpmClientHandler(LanguageHandler):
 
     def on_initialized(self, client) -> None:
         """
-        This method should not be overridden. Use the `on_api_ready` abstraction.
+        This method should not be overridden. Use the `on_ready` abstraction.
         """
-        self.on_api_ready(ApiWrapper(client))
+        self.on_ready(ApiWrapper(client))
 
     def on_ready(self, api: ApiWrapper) -> None:
         pass

--- a/st3/lsp_utils/npm_client_handler.py
+++ b/st3/lsp_utils/npm_client_handler.py
@@ -25,16 +25,16 @@ class ApiWrapper(object):
 
 class NpmClientHandler(LanguageHandler):
     # To be overridden by subclass.
-    PACKAGE_NAME = None
-    SERVER_DIRECTORY = None
-    SERVER_BINARY_PATH = None
+    package_name = None
+    server_directory = None
+    server_binary_path = None
     # Internal
-    __SERVER = None
+    __server = None
 
     def __init__(self):
         super().__init__()
-        assert self.PACKAGE_NAME
-        self.package_name = self.PACKAGE_NAME
+        assert self.package_name
+        self.package_name = self.package_name
         self.settings_filename = '{}.sublime-settings'.format(self.package_name)
 
         # Calling setup() also here as this might run before `plugin_loaded`.
@@ -44,17 +44,17 @@ class NpmClientHandler(LanguageHandler):
 
     @classmethod
     def setup(cls) -> None:
-        assert cls.PACKAGE_NAME
-        assert cls.SERVER_DIRECTORY
-        assert cls.SERVER_BINARY_PATH
-        if not cls.__SERVER:
-            cls.__SERVER = ServerNpmResource(cls.PACKAGE_NAME, cls.SERVER_DIRECTORY, cls.SERVER_BINARY_PATH)
-        cls.__SERVER.setup()
+        assert cls.package_name
+        assert cls.server_directory
+        assert cls.server_binary_path
+        if not cls.__server:
+            cls.__server = ServerNpmResource(cls.package_name, cls.server_directory, cls.server_binary_path)
+        cls.__server.setup()
 
     @classmethod
     def cleanup(cls) -> None:
-        if cls.__SERVER:
-            cls.__SERVER.cleanup()
+        if cls.__server:
+            cls.__server.cleanup()
 
     @property
     def name(self) -> str:
@@ -62,11 +62,11 @@ class NpmClientHandler(LanguageHandler):
 
     @property
     def config(self) -> ClientConfig:
-        assert self.__SERVER
+        assert self.__server
 
         configuration = {
             'enabled': True,
-            'command': ['node', self.__SERVER.binary_path] + self.get_binary_arguments(),
+            'command': ['node', self.__server.binary_path] + self.get_binary_arguments(),
         }
 
         configuration.update(self._read_configuration())
@@ -131,7 +131,9 @@ class NpmClientHandler(LanguageHandler):
         if not self._is_node_installed():
             sublime.status_message("{}: Please install Node.js for the server to work.".format(self.package_name))
             return False
-        return self.server.ready
+        if not self.__server:
+            return False
+        return self.__server.ready
 
     def on_initialized(self, client) -> None:
         """

--- a/st3/lsp_utils/npm_client_handler.py
+++ b/st3/lsp_utils/npm_client_handler.py
@@ -67,7 +67,7 @@ class NpmClientHandler(LanguageHandler):
 
     @property
     def name(self) -> str:
-        return self.package_name.lower()
+        return self.package_name.lower()  # type: ignore
 
     @property
     def config(self) -> ClientConfig:

--- a/st3/lsp_utils/server_npm_resource.py
+++ b/st3/lsp_utils/server_npm_resource.py
@@ -120,7 +120,7 @@ class ServerNpmResource(object):
         self._is_ready = True
         self._stop_indicator()
         log_and_show_message(
-            '{}: Server installed. Supported files might need to be re-opened.'.format(self._package_name))
+            '{}: Server installed. Sublime Text restart might be required.'.format(self._package_name))
 
     def _on_install_error(self, error):
         self._stop_indicator()


### PR DESCRIPTION
Adds `NpmClientHandler` export that at minimium requires only
overriding PACKAGE_NAME, SERVER_DIRECTORY and SERVER_BINARY_PATH class
attributes.