### PR TITLE
Add support for specifying minimum Node version

### DIFF
--- a/st3/lsp_utils/npm_client_handler.py
+++ b/st3/lsp_utils/npm_client_handler.py
@@ -5,7 +5,7 @@ from LSP.plugin.core.protocol import Notification
 from LSP.plugin.core.protocol import Request
 from LSP.plugin.core.protocol import Response
 from LSP.plugin.core.settings import ClientConfig, read_client_config
-from LSP.plugin.core.typing import Any, Callable, Dict, Optional
+from LSP.plugin.core.typing import Any, Callable, Dict, Optional, Tuple
 import shutil
 import sublime
 
@@ -70,7 +70,8 @@ class NpmClientHandler(LanguageHandler):
         assert cls.server_directory
         assert cls.server_binary_path
         if not cls.__server:
-            cls.__server = ServerNpmResource(cls.package_name, cls.server_directory, cls.server_binary_path)
+            cls.__server = ServerNpmResource(cls.package_name, cls.server_directory, cls.server_binary_path,
+                                             cls.minimum_node_version())
         cls.__server.setup()
 
     @classmethod
@@ -81,6 +82,10 @@ class NpmClientHandler(LanguageHandler):
     @property
     def name(self) -> str:
         return self.package_name.lower()  # type: ignore
+
+    @classmethod
+    def minimum_node_version(cls) -> Tuple[int, int, int]:
+        return (8, 0, 0)
 
     @property
     def config(self) -> ClientConfig:

--- a/st3/lsp_utils/npm_client_handler_v2.py
+++ b/st3/lsp_utils/npm_client_handler_v2.py
@@ -59,7 +59,7 @@ class NpmClientHandler(AbstractPlugin):
     server_directory = ''  # type: str
     server_binary_path = ''  # type: str
     # Internal
-    __server = None  # type: ServerNpmResource
+    __server = None  # type: Optional[ServerNpmResource]
 
     @classmethod
     def setup(cls) -> None:
@@ -67,7 +67,8 @@ class NpmClientHandler(AbstractPlugin):
             print('ERROR: [lsp_utils] package_name is required to instantiate an instance of {}'.format(cls))
             return
         if not cls.__server:
-            cls.__server = ServerNpmResource(cls.package_name, cls.server_directory, cls.server_binary_path)
+            cls.__server = ServerNpmResource(cls.package_name, cls.server_directory, cls.server_binary_path,
+                                             cls.minimum_node_version())
             cls.__server.setup()
 
     @classmethod
@@ -78,6 +79,10 @@ class NpmClientHandler(AbstractPlugin):
     @classmethod
     def name(cls) -> str:
         return cls.package_name
+
+    @classmethod
+    def minimum_node_version(cls) -> Tuple[int, int, int]:
+        return (8, 0, 0)
 
     @classmethod
     def needs_update_or_installation(cls) -> bool:

--- a/st3/lsp_utils/server_npm_resource.py
+++ b/st3/lsp_utils/server_npm_resource.py
@@ -1,34 +1,48 @@
+from LSP.plugin.core.typing import Optional, Tuple
+from sublime_lib import ActivityIndicator, ResourcePath
 import os
+import re
 import shutil
 import sublime
 import subprocess
 import threading
 
-from sublime_lib import ActivityIndicator, ResourcePath
 
-
-def run_command(on_exit, on_error, popen_args):
+def run_command(on_success, on_error, popen_args) -> None:
     """
     Runs the given args in a subprocess.Popen, and then calls the function
-    on_exit when the subprocess completes.
-    on_exit is a callable object, and popen_args is a list/tuple of args that
+    on_success when the subprocess completes.
+    on_success is a callable object, and popen_args is a list/tuple of args that
     on_error when the subprocess throws an error
     would give to subprocess.Popen.
     """
-    def run_in_thread(on_exit, on_error, popen_args):
+    def run_in_thread(on_success, on_error, popen_args):
         try:
-            subprocess.check_call(popen_args, shell=sublime.platform() == 'windows')
-            on_exit()
+            output = subprocess.check_output(popen_args, shell=sublime.platform() == 'windows',
+                                             universal_newlines=True, stderr=subprocess.STDOUT)
+            on_success(output.strip())
         except subprocess.CalledProcessError as error:
-            on_error(error)
+            on_error(error.output.strip())
 
-    thread = threading.Thread(target=run_in_thread, args=(on_exit, on_error, popen_args))
+    thread = threading.Thread(target=run_in_thread, args=(on_success, on_error, popen_args))
     thread.start()
-    # returns immediately after the thread starts
-    return thread
 
 
-def log_and_show_message(msg, additional_logs=None, show_in_status=True):
+def parse_version(version: str) -> Tuple[int, int, int]:
+    """Convert filename to version tuple (major, minor, patch)."""
+    match = re.match(r'v?(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-.+)?', version)
+    if match:
+        major, minor, patch = match.groups()
+        return int(major), int(minor), int(patch)
+    else:
+        return 0, 0, 0
+
+
+def version_to_string(version: Tuple[int, int, int]) -> str:
+    return '.'.join([str(c) for c in version])
+
+
+def log_and_show_message(msg, additional_logs: str = None, show_in_status: bool = True) -> None:
     print(msg, '\n', additional_logs) if additional_logs else print(msg)
     if show_in_status:
         sublime.active_window().status_message(msg)
@@ -41,26 +55,28 @@ class ServerNpmResource(object):
     setup() needs to be called during (or after) plugin_loaded() for paths to be valid.
     """
 
-    def __init__(self, package_name, server_directory, server_binary_path):
+    def __init__(self, package_name: str, server_directory: str, server_binary_path: str,
+                 minimum_node_version: Tuple[int, int, int]) -> None:
         self._initialized = False
         self._is_ready = False
         self._package_name = package_name
         self._server_directory = server_directory
         self._binary_path = server_binary_path
-        self._package_cache_path = None
+        self._minimum_node_version = minimum_node_version
+        self._package_cache_path = ''
         self._activity_indicator = None
         if not self._package_name or not self._server_directory or not self._binary_path:
             raise Exception('ServerNpmResource could not initialize due to wrong input')
 
     @property
-    def ready(self):
+    def ready(self) -> bool:
         return self._is_ready
 
     @property
-    def binary_path(self):
+    def binary_path(self) -> str:
         return os.path.join(self._package_cache_path, self._binary_path)
 
-    def setup(self):
+    def setup(self) -> None:
         if self._initialized:
             return
 
@@ -69,11 +85,11 @@ class ServerNpmResource(object):
 
         self._copy_to_cache()
 
-    def cleanup(self):
+    def cleanup(self) -> None:
         if os.path.isdir(self._package_cache_path):
             shutil.rmtree(self._package_cache_path)
 
-    def _copy_to_cache(self):
+    def _copy_to_cache(self) -> None:
         src_path = 'Packages/{}/{}/'.format(self._package_name, self._server_directory)
         dst_path = 'Cache/{}/{}/'.format(self._package_name, self._server_directory)
         cache_server_path = os.path.join(self._package_cache_path, self._server_directory)
@@ -93,15 +109,30 @@ class ServerNpmResource(object):
             # create cache folder
             ResourcePath(src_path).copytree(cache_server_path, exist_ok=True)
 
-        self._install_dependencies(cache_server_path)
-
-    def _install_dependencies(self, cache_server_path):
         dependencies_installed = os.path.isdir(os.path.join(cache_server_path, 'node_modules'))
-
         if dependencies_installed:
             self._is_ready = True
-            return
+        else:
+            self._check_requirements(cache_server_path)
 
+    def _check_requirements(self, server_path: str) -> None:
+        if shutil.which('node') is None:
+            self._on_error('Please install Node.js for the server to work.')
+        else:
+            run_command(
+                lambda version: self._on_check_requirements_result(version, server_path),
+                self._on_error, ['node', '--version'])
+
+    def _on_check_requirements_result(self, version_string: str, server_path: str) -> None:
+        installed_version = parse_version(version_string)
+        if installed_version < self._minimum_node_version:
+            self._on_error(
+                'Installed node version ({}) is lower than required version ({})'.format(
+                    version_to_string(installed_version), version_to_string(self._minimum_node_version)))
+        else:
+            self._install_dependencies(server_path)
+
+    def _install_dependencies(self, server_path: str) -> None:
         # this will be called only when the plugin gets:
         # - installed for the first time,
         # - or when updated on package control
@@ -114,21 +145,21 @@ class ServerNpmResource(object):
             self._activity_indicator.start()
 
         run_command(
-            self._on_install_success, self._on_install_error,
-            ["npm", "install", "--verbose", "--production", "--prefix", cache_server_path, cache_server_path]
+            self._on_install_success, self._on_error,
+            ["npm", "install", "--verbose", "--production", "--prefix", server_path, server_path]
         )
 
-    def _on_install_success(self):
+    def _on_install_success(self, _: str) -> None:
         self._is_ready = True
         self._stop_indicator()
         log_and_show_message(
             '{}: Server installed. Sublime Text restart might be required.'.format(self._package_name))
 
-    def _on_install_error(self, error):
+    def _on_error(self, error: str) -> None:
         self._stop_indicator()
-        log_and_show_message('{}: Error while installing the server.'.format(self._package_name), error)
+        log_and_show_message('{}: Error:'.format(self._package_name), error)
 
-    def _stop_indicator(self):
+    def _stop_indicator(self) -> None:
         if self._activity_indicator:
             self._activity_indicator.stop()
             self._activity_indicator = None


### PR DESCRIPTION
A plugin can define a class method like:

@classmethod
def minimum_node_version(cls) -> Tuple[int, int, int]:
    return (10, 0, 0)

to specify the minimum Node version required by the server. By default
the minimum is v8.

Relates to https://github.com/sublimelsp/LSP-pyright/issues/15