### PR TITLE
Add support for installing servers outside of ST "catalog"

### DIFF
--- a/st3/lsp_utils/npm_client_handler.py
+++ b/st3/lsp_utils/npm_client_handler.py
@@ -72,7 +72,7 @@ class NpmClientHandler(LanguageHandler):
         assert cls.server_binary_path
         if not cls.__server:
             cls.__server = ServerNpmResource(cls.package_name, cls.server_directory, cls.server_binary_path,
-                                             cls.minimum_node_version())
+                                             cls.minimum_node_version(), cls.install_in_cache())
         cls.__server.setup()
 
     @classmethod
@@ -93,6 +93,10 @@ class NpmClientHandler(LanguageHandler):
     @classmethod
     def minimum_node_version(cls) -> Tuple[int, int, int]:
         return (8, 0, 0)
+
+    @classmethod
+    def install_in_cache(cls) -> bool:
+        return True
 
     @property
     def config(self) -> ClientConfig:

--- a/st3/lsp_utils/npm_client_handler_v2.py
+++ b/st3/lsp_utils/npm_client_handler_v2.py
@@ -73,7 +73,8 @@ class NpmClientHandler(AbstractPlugin):
             cls.__server = get_server_npm_resource_for_package(
                 cls.package_name, cls.server_directory, cls.server_binary_path, cls.package_storage(),
                 cls.minimum_node_version())
-            cls.__server.setup()
+            if cls.__server:
+                cls.__server.setup()
 
     @classmethod
     def cleanup(cls) -> None:
@@ -97,6 +98,10 @@ class NpmClientHandler(AbstractPlugin):
         return os.path.join(storage_path, cls.package_name)
 
     @classmethod
+    def binary_path(cls) -> str:
+        return cls.__server.binary_path if cls.__server else ''
+
+    @classmethod
     def install_in_cache(cls) -> bool:
         return True
 
@@ -111,7 +116,7 @@ class NpmClientHandler(AbstractPlugin):
     @classmethod
     def additional_variables(cls) -> Optional[Dict[str, str]]:
         return {
-            'server_path': cls.__server.binary_path
+            'server_path': cls.binary_path()
         }
 
     @classmethod
@@ -121,9 +126,9 @@ class NpmClientHandler(AbstractPlugin):
         basename = "{}.sublime-settings".format(name)
         filepath = "Packages/{}/{}".format(name, basename)
         settings = sublime.load_settings(basename)
-        settings.set('enabled', True)
+        settings.set('enabled', cls.__server != None)
         if not settings.get('command'):
-            settings.set('command', ['node', cls.__server.binary_path] + cls.get_binary_arguments())
+            settings.set('command', ['node', cls.binary_path()] + cls.get_binary_arguments())
         languages = settings.get('languages', None)
         if languages:
             settings.set('languages', cls._upgrade_languages_list(languages))

--- a/st3/lsp_utils/npm_client_handler_v2.py
+++ b/st3/lsp_utils/npm_client_handler_v2.py
@@ -70,7 +70,7 @@ class NpmClientHandler(AbstractPlugin):
             return
         if not cls.__server:
             cls.__server = ServerNpmResource(cls.package_name, cls.server_directory, cls.server_binary_path,
-                                             cls.minimum_node_version())
+                                             cls.minimum_node_version(), cls.install_in_cache())
             cls.__server.setup()
 
     @classmethod
@@ -85,6 +85,10 @@ class NpmClientHandler(AbstractPlugin):
     @classmethod
     def minimum_node_version(cls) -> Tuple[int, int, int]:
         return (8, 0, 0)
+
+    @classmethod
+    def install_in_cache(cls) -> bool:
+        return True
 
     @classmethod
     def needs_update_or_installation(cls) -> bool:

--- a/st3/lsp_utils/server_npm_resource.py
+++ b/st3/lsp_utils/server_npm_resource.py
@@ -87,10 +87,10 @@ class ServerNpmResource(object):
 
         self._initialized = True
         if self._install_in_cache:
-            data_dir = sublime.cache_path()
+            self._package_cache_path = os.path.join(sublime.cache_path(), self._package_name)
         else:
             data_dir = os.path.normpath(os.path.join(sublime.cache_path(), '..'))
-        self._package_cache_path = os.path.join(data_dir, 'LSP Data', self._package_name)
+            self._package_cache_path = os.path.join(data_dir, 'Package Storage', self._package_name)
 
         self._copy_to_cache()
 

--- a/st3/lsp_utils/server_npm_resource.py
+++ b/st3/lsp_utils/server_npm_resource.py
@@ -16,7 +16,10 @@ def get_server_npm_resource_for_package(
     minimum_node_version: SemanticVersion
 ) -> Optional['ServerNpmResource']:
     if shutil.which('node') is None:
-        log_and_show_message('lsp_utils: Node binary not found on the PATH!')
+        log_and_show_message(
+            '{}: Error: Node binary not found on the PATH.'
+            'Check the LSP Troubleshooting section for information on how to fix that: '
+            'https://lsp.readthedocs.io/en/latest/troubleshooting/'.format(package_name))
         return None
     installed_node_version = node_version_resolver.resolve()
     if not installed_node_version:

--- a/st3/lsp_utils/server_npm_resource.py
+++ b/st3/lsp_utils/server_npm_resource.py
@@ -90,7 +90,7 @@ class ServerNpmResource(object):
             data_dir = sublime.cache_path()
         else:
             data_dir = os.path.normpath(os.path.join(sublime.cache_path(), '..'))
-        self._package_cache_path = os.path.join(data_dir, 'LSP-servers', self._package_name)
+        self._package_cache_path = os.path.join(data_dir, 'LSP Data', self._package_name)
 
         self._copy_to_cache()
 

--- a/st3/lsp_utils/server_npm_resource.py
+++ b/st3/lsp_utils/server_npm_resource.py
@@ -126,7 +126,7 @@ class ServerNpmResource:
 
     @property
     def binary_path(self) -> str:
-        return os.path.join(self._package_storage, self._binary_path)
+        return os.path.join(self._package_storage, self._node_version, self._binary_path)
 
     def setup(self) -> None:
         if self._initialized:


### PR DESCRIPTION
A large number of files within directories that ST considers part of the
"catalog" make ST less performant, making catalog queries and ST startup
take a longer time.

Introduced a class method that plugins can override to request being
installed in the "Data/LSP-servers/[PackageName]" directory which is
part of the user settings but not inside directories that are part of
the "catalog".

This needs to be done in an opt-in way instead of just switching directly
in lsp_utils as we need to allow the update flow to run for dependent
packages so that the "plugin_unload" event clears out the old directory.