### PR TITLE
Add VSCode marketplace client handler

### DIFF
--- a/st3/lsp_utils/__init__.py
+++ b/st3/lsp_utils/__init__.py
@@ -5,14 +5,19 @@ except ImportError:
 
 from .api_wrapper import ApiWrapperInterface
 from .server_npm_resource import ServerNpmResource
+from .server_vscode_marketplace_resource import ServerVscodeMarketplaceResource
 
 if lsp_version >= (1, 0, 0):
     from .npm_client_handler_v2 import NpmClientHandler
+    from .vscode_marketplace_client_handler_v2 import VscodeMarketplaceClientHandler
 else:
     from .npm_client_handler import NpmClientHandler
+    from .vscode_marketplace_client_handler import VscodeMarketplaceClientHandler
 
 __all__ = [
     'ApiWrapperInterface',
     'NpmClientHandler',
     'ServerNpmResource',
+    'VscodeMarketplaceClientHandler',
+    'ServerVscodeMarketplaceResource',
 ]

--- a/st3/lsp_utils/server_vscode_marketplace_resource.py
+++ b/st3/lsp_utils/server_vscode_marketplace_resource.py
@@ -6,6 +6,13 @@ import sublime
 import urllib.request
 import zipfile
 
+try:
+    from LSP.plugin.core.views import get_storage_path
+except ImportError:
+    # polyfill for LSP in ST 3
+    def get_storage_path() -> str:
+        return os.path.abspath(os.path.join(sublime.cache_path(), "..", "Package Storage"))
+
 
 def log_and_show_message(msg, additional_logs: str = None, show_in_status: bool = True) -> None:
     print(msg, "\n", additional_logs) if additional_logs else print(msg)
@@ -32,6 +39,7 @@ class ServerVscodeMarketplaceResource(object):
         extension_item_name: str,
         extension_version: str,
         server_binary_path: str,
+        install_in_cache: bool,
     ) -> None:
         self._initialized = False
         self._is_ready = False
@@ -39,6 +47,7 @@ class ServerVscodeMarketplaceResource(object):
         self._extension_item_name = extension_item_name
         self._extension_version = extension_version
         self._binary_path = server_binary_path
+        self._install_in_cache = install_in_cache
         self._package_cache_path = ""
         self._activity_indicator = None
 
@@ -68,7 +77,7 @@ class ServerVscodeMarketplaceResource(object):
 
         self._initialized = True
         self._package_cache_path = os.path.join(
-            sublime.cache_path(),
+            sublime.cache_path() if self._install_in_cache else get_storage_path(),
             self._package_name,
             "{}~{}".format(self._extension_item_name, self._extension_version),
         )

--- a/st3/lsp_utils/server_vscode_marketplace_resource.py
+++ b/st3/lsp_utils/server_vscode_marketplace_resource.py
@@ -1,0 +1,133 @@
+from LSP.plugin.core.typing import Optional
+import gzip
+import os
+import shutil
+import sublime
+import urllib.request
+import zipfile
+
+
+def log_and_show_message(msg, additional_logs: str = None, show_in_status: bool = True) -> None:
+    print(msg, "\n", additional_logs) if additional_logs else print(msg)
+    if show_in_status:
+        sublime.active_window().status_message(msg)
+
+
+class ServerVscodeMarketplaceResource(object):
+    """Global object providing paths to server resources.
+    Also handles the installing and updating of the server in cache.
+
+    setup() needs to be called during (or after) plugin_loaded() for paths to be valid.
+
+    For example, for https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance
+        - extension_item_name is "ms-python.vscode-pylance"
+        - extension_version is like "2020.10.1"
+    """
+
+    extension_download_pattern = "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/{vendor}/vsextensions/{name}/{version}/vspackage"
+
+    def __init__(
+        self,
+        package_name: str,
+        extension_item_name: str,
+        extension_version: str,
+        server_binary_path: str,
+    ) -> None:
+        self._initialized = False
+        self._is_ready = False
+        self._package_name = package_name
+        self._extension_item_name = extension_item_name
+        self._extension_version = extension_version
+        self._binary_path = server_binary_path
+        self._package_cache_path = ""
+        self._activity_indicator = None
+
+        if (
+            not self._package_name
+            or not self._extension_item_name
+            or not self._extension_version
+            or not self._binary_path
+        ):
+            raise Exception("ServerVscodeMarketplaceResource could not initialize due to wrong input")
+
+    @property
+    def ready(self) -> bool:
+        return self._is_ready
+
+    @property
+    def binary_path(self) -> str:
+        return os.path.join(self._package_cache_path, self._binary_path)
+
+    @property
+    def package_cache_path(self) -> str:
+        return self._package_cache_path
+
+    def setup(self) -> None:
+        if self._initialized:
+            return
+
+        self._initialized = True
+        self._package_cache_path = os.path.join(
+            sublime.cache_path(),
+            self._package_name,
+            "{}~{}".format(self._extension_item_name, self._extension_version),
+        )
+
+        if not os.path.isfile(self.binary_path):
+            self._download_extension()
+
+        if os.path.isfile(self.binary_path):
+            self._is_ready = True
+
+    def cleanup(self) -> None:
+        if os.path.isdir(self._package_cache_path):
+            shutil.rmtree(self._package_cache_path)
+
+    def _download_extension(self) -> None:
+        vsix_path = os.path.join(self._package_cache_path, "extension.vsix")
+        extension_vendor, extension_name = self._extension_item_name.split(".")
+
+        response = urllib.request.urlopen(
+            self.extension_download_pattern.format(
+                vendor=extension_vendor,
+                name=extension_name,
+                version=self._extension_version,
+            )
+        )
+
+        response_data = response.read()
+        if response.info().get("Content-Encoding") == "gzip":
+            response_data = gzip.decompress(response_data)
+
+        os.makedirs(os.path.dirname(vsix_path), exist_ok=True)
+        with open(vsix_path, "wb") as f:
+            f.write(response_data)
+        self._decompress_vsix(vsix_path)
+
+    def _on_install_success(self, _: str) -> None:
+        self._is_ready = True
+        self._stop_indicator()
+        log_and_show_message("{}: Server installed. Sublime Text restart might be required.".format(self._package_name))
+
+    def _on_error(self, error: str) -> None:
+        self._stop_indicator()
+        log_and_show_message("{}: Error:".format(self._package_name), error)
+
+    def _stop_indicator(self) -> None:
+        if self._activity_indicator:
+            self._activity_indicator.stop()
+            self._activity_indicator = None
+
+    def _decompress_vsix(self, file: str, dst_dir: Optional[str] = None) -> None:
+        """
+        @brief Decompress the .vsix tarball.
+
+        @param file    The .vsix tarball
+        @param dst_dir The destination directory
+        """
+
+        if not dst_dir:
+            dst_dir = os.path.dirname(file)
+
+        with zipfile.ZipFile(file) as f:
+            f.extractall(dst_dir)

--- a/st3/lsp_utils/vscode_marketplace_client_handler.py
+++ b/st3/lsp_utils/vscode_marketplace_client_handler.py
@@ -1,5 +1,5 @@
-from .api_wrapper import ApiWrapperInterface
 from .server_vscode_marketplace_resource import ServerVscodeMarketplaceResource
+from lsp_utils.api_wrapper import ApiWrapperInterface
 from LSP.plugin.core.handlers import LanguageHandler
 from LSP.plugin.core.protocol import Notification
 from LSP.plugin.core.protocol import Request
@@ -81,6 +81,7 @@ class VscodeMarketplaceClientHandler(LanguageHandler):
                 cls.extension_item_name,
                 cls.extension_version,
                 cls.server_binary_path,
+                cls.install_in_cache(),
             )
         cls.__server.setup()
 
@@ -92,6 +93,10 @@ class VscodeMarketplaceClientHandler(LanguageHandler):
     @property
     def name(self) -> str:
         return self.package_name.lower()  # type: ignore
+
+    @classmethod
+    def install_in_cache(cls) -> bool:
+        return False
 
     @classmethod
     def additional_variables(cls) -> Optional[Dict[str, str]]:

--- a/st3/lsp_utils/vscode_marketplace_client_handler.py
+++ b/st3/lsp_utils/vscode_marketplace_client_handler.py
@@ -1,0 +1,195 @@
+from .api_wrapper import ApiWrapperInterface
+from .server_vscode_marketplace_resource import ServerVscodeMarketplaceResource
+from LSP.plugin.core.handlers import LanguageHandler
+from LSP.plugin.core.protocol import Notification
+from LSP.plugin.core.protocol import Request
+from LSP.plugin.core.protocol import Response
+from LSP.plugin.core.settings import ClientConfig, read_client_config
+from LSP.plugin.core.typing import Any, Callable, Dict, List, Optional, Tuple
+import shutil
+import sublime
+
+# Keys to read and their fallbacks.
+CLIENT_SETTING_KEYS = {
+    "command": [],
+    "env": {},
+    "experimental_capabilities": {},
+    "languages": [],
+    "initializationOptions": {},
+    "settings": {},
+}  # type: ignore
+
+
+def is_node_installed():
+    return shutil.which("node") is not None
+
+
+class ApiWrapper(ApiWrapperInterface):
+    def __init__(self, client):
+        self.__client = client
+
+    def on_notification(self, method: str, handler: Callable) -> None:
+        self.__client.on_notification(method, handler)
+
+    def on_request(self, method: str, handler: Callable) -> None:
+        def on_response(params, request_id):
+            handler(params, lambda result: send_response(request_id, result))
+
+        def send_response(request_id, result):
+            self.__client.send_response(Response(request_id, result))
+
+        self.__client.on_request(method, on_response)
+
+    def send_notification(self, method: str, params: Any) -> None:
+        self.__client.send_notification(Notification(method, params))
+
+    def send_request(self, method: str, params: Any, handler: Callable[[Optional[str], bool], None]) -> None:
+        self.__client.send_request(
+            Request(method, params),
+            lambda result: handler(result, False),
+            lambda result: handler(result, True),
+        )
+
+
+class VscodeMarketplaceClientHandler(LanguageHandler):
+    package_name = ""  # type: str
+    extension_item_name = ""  # type: str
+    extension_version = ""  # type: str
+    server_binary_path = ""  # type: str
+    execute_with_node = False  # type: bool
+    # Internal
+    __server = None  # type: Optional[ServerVscodeMarketplaceResource]
+
+    def __init__(self):
+        super().__init__()
+        assert self.package_name
+        self.settings_filename = "{}.sublime-settings".format(self.package_name)
+        # Calling setup() also here as this might run before `plugin_loaded`.
+        # Will be a no-op if already ran.
+        # See https://github.com/sublimelsp/LSP/issues/899
+        self.setup()
+
+    @classmethod
+    def setup(cls) -> None:
+        assert cls.package_name
+        assert cls.extension_item_name
+        assert cls.extension_version
+        assert cls.server_binary_path
+        if not cls.__server:
+            cls.__server = ServerVscodeMarketplaceResource(
+                cls.package_name,
+                cls.extension_item_name,
+                cls.extension_version,
+                cls.server_binary_path,
+            )
+        cls.__server.setup()
+
+    @classmethod
+    def cleanup(cls) -> None:
+        if cls.__server:
+            cls.__server.cleanup()
+
+    @property
+    def name(self) -> str:
+        return self.package_name.lower()  # type: ignore
+
+    @classmethod
+    def additional_variables(cls) -> Optional[Dict[str, str]]:
+        return {
+            "package_cache_path": cls.__server.package_cache_path,
+            "server_path": cls.__server.binary_path,
+        }
+
+    @property
+    def config(self) -> ClientConfig:
+        assert self.__server
+
+        configuration = {"enabled": True}  # type: Dict[str, Any]
+        configuration.update(self._read_configuration())
+
+        if not configuration["command"]:
+            configuration["command"] = (
+                (["node"] if self.execute_with_node else [])
+                + [self.__server.binary_path]
+                + self.get_binary_arguments()
+            )
+
+        self.on_client_configuration_ready(configuration)
+        base_settings_path = "Packages/{}/{}".format(self.package_name, self.settings_filename)
+        return read_client_config(self.name, configuration, base_settings_path)
+
+    @classmethod
+    def get_binary_arguments(cls) -> List[str]:
+        """
+        Returns a list of extra arguments to append when starting server.
+        """
+        return ["--stdio"] if cls.execute_with_node else []
+
+    def _read_configuration(self) -> Dict:
+        settings = {}  # type: Dict
+        loaded_settings = sublime.load_settings(self.settings_filename)
+
+        if loaded_settings:
+            migrated = self._migrate_obsolete_settings(loaded_settings)
+            changed = self.on_settings_read(loaded_settings)
+            if migrated or changed:
+                sublime.save_settings(self.settings_filename)
+
+            for key, default in CLIENT_SETTING_KEYS.items():
+                settings[key] = loaded_settings.get(key, default)
+
+        return settings
+
+    @classmethod
+    def on_settings_read(cls, settings: sublime.Settings):
+        """
+        Called when package settings were read. Receives a `sublime.Settings` object.
+
+        Can be used to change user settings, migrating them to new schema, for example.
+
+        Return True if settings were modified to save changes to file.
+        """
+        return False
+
+    def _migrate_obsolete_settings(self, settings: sublime.Settings):
+        """
+        Migrates setting with a root `client` key to flattened structure.
+        Receives a `sublime.Settings` object.
+
+        Returns True if settings were migrated.
+        """
+        client = settings.get("client")  # type: Dict
+        if client:
+            settings.erase("client")
+            # Migrate old keys
+            for key, value in client.items():
+                settings.set(key, value)
+            return True
+        return False
+
+    @classmethod
+    def on_client_configuration_ready(cls, configuration: Dict) -> None:
+        """
+        Called with default configuration object that contains merged default and user settings.
+
+        Can be used to alter default configuration before registering it.
+        """
+        pass
+
+    @classmethod
+    def on_start(cls, window) -> bool:
+        if not is_node_installed():
+            sublime.status_message("{}: Please install Node.js for the server to work.".format(cls.package_name))
+            return False
+        if not cls.__server:
+            return False
+        return cls.__server.ready
+
+    def on_initialized(self, client) -> None:
+        """
+        This method should not be overridden. Use the `on_ready` abstraction.
+        """
+        self.on_ready(ApiWrapper(client))
+
+    def on_ready(self, api: ApiWrapper) -> None:
+        pass

--- a/st3/lsp_utils/vscode_marketplace_client_handler_v2.py
+++ b/st3/lsp_utils/vscode_marketplace_client_handler_v2.py
@@ -1,5 +1,5 @@
-from .api_wrapper import ApiWrapperInterface
 from .server_vscode_marketplace_resource import ServerVscodeMarketplaceResource
+from lsp_utils.api_wrapper import ApiWrapperInterface
 from LSP.plugin import AbstractPlugin
 from LSP.plugin import ClientConfig
 from LSP.plugin import Notification
@@ -79,6 +79,7 @@ class VscodeMarketplaceClientHandler(AbstractPlugin):
                 cls.extension_item_name,
                 cls.extension_version,
                 cls.server_binary_path,
+                cls.install_in_cache(),
             )
             cls.__server.setup()
 
@@ -90,6 +91,10 @@ class VscodeMarketplaceClientHandler(AbstractPlugin):
     @classmethod
     def name(cls) -> str:
         return cls.package_name
+
+    @classmethod
+    def install_in_cache(cls) -> bool:
+        return False
 
     @classmethod
     def needs_update_or_installation(cls) -> bool:

--- a/st3/lsp_utils/vscode_marketplace_client_handler_v2.py
+++ b/st3/lsp_utils/vscode_marketplace_client_handler_v2.py
@@ -1,0 +1,204 @@
+from .api_wrapper import ApiWrapperInterface
+from .server_vscode_marketplace_resource import ServerVscodeMarketplaceResource
+from LSP.plugin import AbstractPlugin
+from LSP.plugin import ClientConfig
+from LSP.plugin import Notification
+from LSP.plugin import Request
+from LSP.plugin import Response
+from LSP.plugin import Session
+from LSP.plugin import WorkspaceFolder
+from LSP.plugin.core.rpc import method2attr
+from LSP.plugin.core.typing import Any, Callable, Dict, List, Optional, Tuple
+import shutil
+import sublime
+import weakref
+
+# Keys to read and their fallbacks.
+CLIENT_SETTING_KEYS = {
+    "command": [],
+    "env": {},
+    "experimental_capabilities": {},
+    "languages": [],
+    "initializationOptions": {},
+    "settings": {},
+}  # type: ignore
+
+
+class ApiWrapper(ApiWrapperInterface):
+    def __init__(self, plugin: AbstractPlugin):
+        self.__plugin = plugin
+
+    def on_notification(self, method: str, handler: Callable) -> None:
+        setattr(self.__plugin, method2attr(method), lambda params: handler(params))
+
+    def on_request(self, method: str, handler: Callable) -> None:
+        def send_response(request_id, result):
+            session = self.__plugin.weaksession()
+            if session:
+                session.send_response(Response(request_id, result))
+
+        def on_response(params, request_id):
+            handler(params, lambda result: send_response(request_id, result))
+
+        setattr(self.__plugin, method2attr(method), on_response)
+
+    def send_notification(self, method: str, params: Any) -> None:
+        session = self.__plugin.weaksession()
+        if session:
+            session.send_notification(Notification(method, params))
+
+    def send_request(self, method: str, params: Any, handler: Callable[[Optional[str], bool], None]) -> None:
+        session = self.__plugin.weaksession()
+        if session:
+            session.send_request(
+                Request(method, params),
+                lambda result: handler(result, False),
+                lambda result: handler(result, True),
+            )
+        else:
+            handler(None, True)
+
+
+class VscodeMarketplaceClientHandler(AbstractPlugin):
+    package_name = ""  # type: str
+    extension_item_name = ""  # type: str
+    extension_version = ""  # type: str
+    server_binary_path = ""  # type: str
+    execute_with_node = False  # type: bool
+    # Internal
+    __server = None  # type: Optional[ServerVscodeMarketplaceResource]
+
+    @classmethod
+    def setup(cls) -> None:
+        if not cls.package_name:
+            print("ERROR: [lsp_utils] package_name is required to instantiate an instance of {}".format(cls))
+            return
+        if not cls.__server:
+            cls.__server = ServerVscodeMarketplaceResource(
+                cls.package_name,
+                cls.extension_item_name,
+                cls.extension_version,
+                cls.server_binary_path,
+            )
+            cls.__server.setup()
+
+    @classmethod
+    def cleanup(cls) -> None:
+        if cls.__server:
+            cls.__server.cleanup()
+
+    @classmethod
+    def name(cls) -> str:
+        return cls.package_name
+
+    @classmethod
+    def needs_update_or_installation(cls) -> bool:
+        return False
+
+    @classmethod
+    def install_or_update(cls) -> None:
+        pass
+
+    @classmethod
+    def additional_variables(cls) -> Optional[Dict[str, str]]:
+        return {
+            "package_cache_path": cls.__server.package_cache_path,
+            "server_path": cls.__server.binary_path,
+        }
+
+    @classmethod
+    def configuration(cls) -> Tuple[sublime.Settings, str]:
+        cls.setup()
+        name = cls.name()
+        basename = "{}.sublime-settings".format(name)
+        filepath = "Packages/{}/{}".format(name, basename)
+        settings = sublime.load_settings(basename)
+        settings.set("enabled", True)
+        if not settings.get("command"):
+            settings.set(
+                "command",
+                (["node"] if cls.execute_with_node else []) + [cls.__server.binary_path] + cls.get_binary_arguments(),
+            )
+        languages = settings.get("languages", None)
+        if languages:
+            settings.set("languages", cls._upgrade_languages_list(languages))
+        cls.on_settings_read(settings)
+        # Read into a dict so we can call old API "on_client_configuration_ready" and then
+        # resave potentially changed values.
+        settings_dict = {}
+        for key, default in CLIENT_SETTING_KEYS.items():
+            settings_dict[key] = settings.get(key, default)
+        cls.on_client_configuration_ready(settings_dict)
+        for key in CLIENT_SETTING_KEYS.keys():
+            settings.set(key, settings_dict[key])
+
+        return settings, filepath
+
+    @classmethod
+    def _upgrade_languages_list(cls, languages):
+        upgraded_list = []
+        for language in languages:
+            if "document_selector" in language:
+                language.pop("scopes", None)
+                language.pop("syntaxes", None)
+                upgraded_list.append(language)
+            elif "scopes" in language:
+                upgraded_list.append(
+                    {
+                        "languageId": language.get("languageId"),
+                        "document_selector": " | ".join(language.get("scopes")),
+                    }
+                )
+            else:
+                upgraded_list.append(language)
+        return upgraded_list
+
+    @classmethod
+    def get_binary_arguments(cls) -> List[str]:
+        """
+        Returns a list of extra arguments to append when starting server.
+        """
+        return ["--stdio"] if cls.execute_with_node else []
+
+    @classmethod
+    def on_settings_read(cls, settings: sublime.Settings):
+        """
+        Called when package settings were read. Receives a `sublime.Settings` object.
+
+        Can be used to change user settings, migrating them to new schema, for example.
+
+        Return True if settings were modified to save changes to file.
+        """
+        return False
+
+    @classmethod
+    def on_client_configuration_ready(cls, configuration: Dict) -> None:
+        """
+        Called with default configuration object that contains merged default and user settings.
+
+        Can be used to alter default configuration before registering it.
+        """
+        pass
+
+    @classmethod
+    def can_start(
+        cls,
+        window: sublime.Window,
+        initiating_view: sublime.View,
+        workspace_folders: List[WorkspaceFolder],
+        configuration: ClientConfig,
+    ) -> Optional[str]:
+        if cls.execute_with_node and shutil.which("node") is None:
+            return "{}: Please install Node.js for the server to work.".format(cls.package_name)
+        if not cls.__server or not cls.__server.ready:
+            return "{}: Server installation in progress.".format(cls.package_name)
+        return None
+
+    def __init__(self, weaksession: "weakref.ref[Session]") -> None:
+        super().__init__(weaksession)
+        if not self.package_name:
+            return
+        self.on_ready(ApiWrapper(self))
+
+    def on_ready(self, api: ApiWrapper) -> None:
+        pass


### PR DESCRIPTION
There are some LSP servers, which are only available either on VSCode's marketplace or as `.vsix` files.

- TailwindCSS: https://github.com/tailwindlabs/tailwindcss-intellisense
  which was asked on https://github.com/sublimelsp/LSP/issues/1377#issuecomment-711036812
- Roblox: https://marketplace.visualstudio.com/items?itemName=Nightrains.robloxlsp
  which was asked on https://discordapp.com/channels/280102180189634562/645268178397560865/767193838379859969

This PR proposes a dedicated handler, which should simplify `LSP-*` plugin codes for them.

It

- downloads the extension from the marketplace with given extension `itemName` and `version`
- unzips the downloaded `.vsix` file
- checks `node` executable availability if necessary


---

An example use for https://marketplace.visualstudio.com/items?itemName=Nightrains.robloxlsp

<details>

```py
import os
import sublime

from LSP.plugin.core.typing import List
from lsp_utils import VscodeMarketplaceClientHandler


def get_server_bin_path(platform: str = sublime.platform()) -> str:
    """
    @brief Get the LSP server binary path.
    @param platform The platform ("osx", "linux" or "windows")
    @return The LSP server binary path.
    """

    os_bin = {
        "linux": ["Linux", "lua-language-server"],
        "osx": ["macOS", "lua-language-server"],
        "windows": ["Windows", "lua-language-server.exe"],
    }

    return os.path.join("extension", "server", "bin", *(os_bin[platform]))


class LspRobloxPlugin(VscodeMarketplaceClientHandler):
    package_name = "LSP-Roblox"

    # @see https://marketplace.visualstudio.com/items?itemName=Nightrains.robloxlsp
    extension_item_name = "Nightrains.robloxlsp"
    extension_version = "0.11.5"
    server_binary_path = get_server_bin_path()
    execute_with_node = False

    @classmethod
    def get_binary_arguments(cls) -> List[str]:
        basename = "{}.sublime-settings".format(cls.package_name)
        settings = sublime.load_settings(basename)

        return [
            "-E",
            os.path.join(
                "${package_cache_path}",
                "extension",
                "server",
                settings.get("main_lua_file"),
            ),
        ]
```

</details>
