### PR TITLE
Make ST4 handler use AbstractPlugin installation flow

### DIFF
--- a/st3/lsp_utils/helpers.py
+++ b/st3/lsp_utils/helpers.py
@@ -1,0 +1,58 @@
+from LSP.plugin.core.typing import Callable, List, Optional, Tuple
+import re
+import sublime
+import subprocess
+import threading
+
+StringCallback = Callable[[str], None]
+SemanticVersion = Tuple[int, int, int]
+
+
+def run_command_sync(args: List[str]) -> Tuple[str, Optional[str]]:
+    try:
+        output = subprocess.check_output(
+            args, shell=sublime.platform() == 'windows', stderr=subprocess.STDOUT)
+        return (decode_bytes(output).strip(), None)
+    except subprocess.CalledProcessError as error:
+        return ('', decode_bytes(error.output).strip())
+
+
+def run_command_async(popen_args, on_success: StringCallback, on_error: StringCallback) -> None:
+    """
+    Runs the given args in a subprocess.Popen, and then calls the function
+    on_success when the subprocess completes.
+    on_success is a callable object, and popen_args is a list/tuple of args that
+    on_error when the subprocess throws an error
+    would give to subprocess.Popen.
+    """
+
+    def execute(on_success, on_error, popen_args):
+        result, error = run_command_sync(popen_args)
+        on_error(error) if error is not None else on_success(result)
+
+    thread = threading.Thread(target=execute, args=(on_success, on_error, popen_args))
+    thread.start()
+
+
+def decode_bytes(data: bytes) -> str:
+    return data.decode('utf-8', 'ignore')
+
+
+def parse_version(version: str) -> SemanticVersion:
+    """Convert filename to version tuple (major, minor, patch)."""
+    match = re.match(r'v?(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-.+)?', version)
+    if match:
+        major, minor, patch = match.groups()
+        return int(major), int(minor), int(patch)
+    else:
+        return 0, 0, 0
+
+
+def version_to_string(version: SemanticVersion) -> str:
+    return '.'.join([str(c) for c in version])
+
+
+def log_and_show_message(msg, additional_logs: str = None, show_in_status: bool = True) -> None:
+    print(msg, '\n', additional_logs) if additional_logs else print(msg)
+    if show_in_status:
+        sublime.active_window().status_message(msg)

--- a/st3/lsp_utils/npm_client_handler.py
+++ b/st3/lsp_utils/npm_client_handler.py
@@ -7,6 +7,7 @@ from LSP.plugin.core.protocol import Response
 from LSP.plugin.core.settings import ClientConfig, read_client_config
 from LSP.plugin.core.typing import Any, Callable, Dict, Optional, Tuple
 import os
+import shutil
 import sublime
 
 # Keys to read and their fallbacks.
@@ -75,8 +76,8 @@ class NpmClientHandler(LanguageHandler):
 
     @classmethod
     def cleanup(cls) -> None:
-        if cls.__server:
-            cls.__server.cleanup()
+        if os.path.isdir(cls.package_storage()):
+            shutil.rmtree(cls.package_storage())
 
     @property
     def name(self) -> str:

--- a/st3/lsp_utils/npm_client_handler_v2.py
+++ b/st3/lsp_utils/npm_client_handler_v2.py
@@ -75,8 +75,8 @@ class NpmClientHandler(AbstractPlugin):
     @classmethod
     def cleanup(cls) -> None:
         unregister_plugin(cls)
-        if cls.__server:
-            cls.__server.cleanup()
+        if os.path.isdir(cls.package_storage()):
+            shutil.rmtree(cls.package_storage())
 
     @classmethod
     def name(cls) -> str:

--- a/st3/lsp_utils/npm_client_handler_v2.py
+++ b/st3/lsp_utils/npm_client_handler_v2.py
@@ -195,8 +195,9 @@ class NpmClientHandler(AbstractPlugin):
             return "{}: Error installing server dependencies.".format(cls.package_name)
         if not cls.__server.ready:
             return "{}: Server installation in progress...".format(cls.package_name)
-        # Lazily update command after server has initialized.
-        configuration.command = ['node', cls.binary_path()] + cls.get_binary_arguments()
+        # Lazily update command after server has initialized if not set manually by the user.
+        if not configuration.command:
+            configuration.command = ['node', cls.binary_path()] + cls.get_binary_arguments()
         return None
 
     def __init__(self, weaksession: 'weakref.ref[Session]') -> None:

--- a/st3/lsp_utils/npm_client_handler_v2.py
+++ b/st3/lsp_utils/npm_client_handler_v2.py
@@ -3,9 +3,11 @@ from .server_npm_resource import get_server_npm_resource_for_package, ServerNpmR
 from LSP.plugin import AbstractPlugin
 from LSP.plugin import ClientConfig
 from LSP.plugin import Notification
+from LSP.plugin import register_plugin
 from LSP.plugin import Request
 from LSP.plugin import Response
 from LSP.plugin import Session
+from LSP.plugin import unregister_plugin
 from LSP.plugin import WorkspaceFolder
 from LSP.plugin.core.rpc import method2attr
 from LSP.plugin.core.typing import Any, Callable, Dict, List, Optional, Tuple
@@ -66,18 +68,13 @@ class NpmClientHandler(AbstractPlugin):
 
     @classmethod
     def setup(cls) -> None:
+        register_plugin(cls)
         if not cls.package_name:
             print('ERROR: [lsp_utils] package_name is required to instantiate an instance of {}'.format(cls))
-            return
-        if not cls.__server:
-            cls.__server = get_server_npm_resource_for_package(
-                cls.package_name, cls.server_directory, cls.server_binary_path, cls.package_storage(),
-                cls.minimum_node_version())
-            if cls.__server:
-                cls.__server.setup()
 
     @classmethod
     def cleanup(cls) -> None:
+        unregister_plugin(cls)
         if cls.__server:
             cls.__server.cleanup()
 
@@ -106,14 +103,6 @@ class NpmClientHandler(AbstractPlugin):
         return True
 
     @classmethod
-    def needs_update_or_installation(cls) -> bool:
-        return False
-
-    @classmethod
-    def install_or_update(cls) -> None:
-        pass
-
-    @classmethod
     def additional_variables(cls) -> Optional[Dict[str, str]]:
         return {
             'server_path': cls.binary_path()
@@ -121,14 +110,11 @@ class NpmClientHandler(AbstractPlugin):
 
     @classmethod
     def configuration(cls) -> Tuple[sublime.Settings, str]:
-        cls.setup()
         name = cls.name()
         basename = "{}.sublime-settings".format(name)
         filepath = "Packages/{}/{}".format(name, basename)
         settings = sublime.load_settings(basename)
-        settings.set('enabled', cls.__server != None)
-        if not settings.get('command'):
-            settings.set('command', ['node', cls.binary_path()] + cls.get_binary_arguments())
+        settings.set('enabled', True)
         languages = settings.get('languages', None)
         if languages:
             settings.set('languages', cls._upgrade_languages_list(languages))
@@ -189,12 +175,28 @@ class NpmClientHandler(AbstractPlugin):
         pass
 
     @classmethod
+    def needs_update_or_installation(cls) -> bool:
+        if not cls.__server:
+            cls.__server = get_server_npm_resource_for_package(
+                cls.package_name, cls.server_directory, cls.server_binary_path, cls.package_storage(),
+                cls.minimum_node_version())
+            if cls.__server:
+                return cls.__server.needs_installation()
+        return False
+
+    @classmethod
+    def install_or_update(cls) -> None:
+        cls.__server.install_or_update(async_io=False)
+
+    @classmethod
     def can_start(cls, window: sublime.Window, initiating_view: sublime.View,
                   workspace_folders: List[WorkspaceFolder], configuration: ClientConfig) -> Optional[str]:
-        if shutil.which('node') is None:
-            return "{}: Please install Node.js for the server to work.".format(cls.package_name)
-        if not cls.__server or not cls.__server.ready:
-            return "{}: Server installation in progress.".format(cls.package_name)
+        if not cls.__server or cls.__server.error_on_install:
+            return "{}: Error installing server dependencies.".format(cls.package_name)
+        if not cls.__server.ready:
+            return "{}: Server installation in progress...".format(cls.package_name)
+        # Lazily update command after server has initialized.
+        configuration.command = ['node', cls.binary_path()] + cls.get_binary_arguments()
         return None
 
     def __init__(self, weaksession: 'weakref.ref[Session]') -> None:

--- a/st3/lsp_utils/server_npm_resource.py
+++ b/st3/lsp_utils/server_npm_resource.py
@@ -1,14 +1,14 @@
+from .helpers import log_and_show_message
+from .helpers import parse_version
+from .helpers import run_command_async
+from .helpers import run_command_sync
+from .helpers import SemanticVersion
+from .helpers import version_to_string
 from LSP.plugin.core.typing import Callable, List, Optional, Tuple
 from sublime_lib import ActivityIndicator, ResourcePath
 import os
-import re
 import shutil
 import sublime
-import subprocess
-import threading
-
-StringCallback = Callable[[str], None]
-SemanticVersion = Tuple[int, int, int]
 
 
 def get_server_npm_resource_for_package(
@@ -33,51 +33,6 @@ def get_server_npm_resource_for_package(
                              version_to_string(installed_node_version))
 
 
-def run_command(on_success: StringCallback, on_error: StringCallback, popen_args) -> None:
-    """
-    Runs the given args in a subprocess.Popen, and then calls the function
-    on_success when the subprocess completes.
-    on_success is a callable object, and popen_args is a list/tuple of args that
-    on_error when the subprocess throws an error
-    would give to subprocess.Popen.
-    """
-
-    def execute(on_success, on_error, popen_args):
-        try:
-            output = subprocess.check_output(popen_args, shell=sublime.platform() == 'windows',
-                                             stderr=subprocess.STDOUT)
-            on_success(decode_bytes(output).strip())
-        except subprocess.CalledProcessError as error:
-            on_error(decode_bytes(error.output).strip())
-
-    thread = threading.Thread(target=execute, args=(on_success, on_error, popen_args))
-    thread.start()
-
-
-def decode_bytes(data: bytes) -> str:
-    return data.decode('utf-8', 'ignore')
-
-
-def parse_version(version: str) -> SemanticVersion:
-    """Convert filename to version tuple (major, minor, patch)."""
-    match = re.match(r'v?(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-.+)?', version)
-    if match:
-        major, minor, patch = match.groups()
-        return int(major), int(minor), int(patch)
-    else:
-        return 0, 0, 0
-
-
-def version_to_string(version: SemanticVersion) -> str:
-    return '.'.join([str(c) for c in version])
-
-
-def log_and_show_message(msg, additional_logs: str = None, show_in_status: bool = True) -> None:
-    print(msg, '\n', additional_logs) if additional_logs else print(msg)
-    if show_in_status:
-        sublime.active_window().status_message(msg)
-
-
 class NodeVersionResolver:
     """
     A singleton for resolving Node version once per session.
@@ -88,15 +43,11 @@ class NodeVersionResolver:
     def resolve(self) -> Optional[SemanticVersion]:
         if self._version:
             return self._version
-
-        try:
-            output = subprocess.check_output(
-                ['node', '--version'], shell=sublime.platform() == 'windows', stderr=subprocess.STDOUT)
-            self._version = parse_version(decode_bytes(output).strip())
-        except subprocess.CalledProcessError as error:
-            error = decode_bytes(error.output).strip()
+        version, error = run_command_sync(['node', '--version'])
+        if error is not None:
             log_and_show_message('lsp_utils(NodeVersionResolver): Error resolving node version: {}!'.format(error))
-
+        else:
+            self._version = parse_version(version)
         return self._version
 
 
@@ -114,6 +65,7 @@ class ServerNpmResource:
                  package_storage: str, node_version: str) -> None:
         self._initialized = False
         self._is_ready = False
+        self._error_on_install = False
         self._package_name = package_name
         self._server_directory = server_directory
         self._binary_path = server_binary_path
@@ -128,47 +80,54 @@ class ServerNpmResource:
         return self._is_ready
 
     @property
+    def error_on_install(self) -> bool:
+        return self._error_on_install
+
+    @property
     def binary_path(self) -> str:
         return os.path.join(self._package_storage, self._node_version, self._binary_path)
 
-    def setup(self) -> None:
-        if self._initialized:
-            return
+    @property
+    def src_path(self) -> str:
+        return 'Packages/{}/{}/'.format(self._package_name, self._server_directory)
 
-        self._initialized = True
-        self._copy_to_storage()
+    @property
+    def dst_path(self) -> str:
+        return os.path.join(self._package_storage, self._node_version, self._server_directory)
 
     def cleanup(self) -> None:
         if os.path.isdir(self._package_storage):
             shutil.rmtree(self._package_storage)
 
-    def _copy_to_storage(self) -> None:
-        src_path = 'Packages/{}/{}/'.format(self._package_name, self._server_directory)
-        dst_path = os.path.join(self._package_storage, self._node_version, self._server_directory)
-
-        if os.path.isdir(dst_path):
-            # Server already in cache. Check if version has changed and if so, delete existing copy in cache.
+    def needs_installation(self) -> bool:
+        if self._initialized:
+            return False
+        self._initialized = True
+        installed = False
+        if os.path.isdir(self.dst_path):
+            # Server already installed. Check if version has changed.
             try:
-                src_package_json = ResourcePath(src_path, 'package.json').read_text()
-                with open(os.path.join(dst_path, 'package.json'), 'r') as file:
+                src_package_json = ResourcePath(self.src_path, 'package.json').read_text()
+                with open(os.path.join(self.dst_path, 'package.json'), 'r') as file:
                     dst_package_json = file.read()
-
-                if src_package_json != dst_package_json:
-                    shutil.rmtree(dst_path)
+                if src_package_json == dst_package_json:
+                    installed = True
             except FileNotFoundError:
-                shutil.rmtree(dst_path)
+                # Needs to be re-installed.
+                pass
+        self._is_ready = installed
+        return not installed
 
-        if not os.path.isdir(dst_path):
-            # create cache folder
-            ResourcePath(src_path).copytree(dst_path, exist_ok=True)
-
-        dependencies_installed = os.path.isdir(os.path.join(dst_path, 'node_modules'))
+    def install_or_update(self, async_io: bool) -> None:
+        shutil.rmtree(self.dst_path, ignore_errors=True)
+        ResourcePath(self.src_path).copytree(self.dst_path, exist_ok=True)
+        dependencies_installed = os.path.isdir(os.path.join(self.dst_path, 'node_modules'))
         if dependencies_installed:
             self._is_ready = True
         else:
-            self._install_dependencies(dst_path)
+            self._install_dependencies(self.dst_path, async_io)
 
-    def _install_dependencies(self, server_path: str) -> None:
+    def _install_dependencies(self, server_path: str, async_io: bool) -> None:
         # this will be called only when the plugin gets:
         # - installed for the first time,
         # - or when updated on package control
@@ -180,10 +139,12 @@ class ServerNpmResource:
             self._activity_indicator = ActivityIndicator(active_window.active_view(), install_message)
             self._activity_indicator.start()
 
-        run_command(
-            self._on_install_success, self._on_error,
-            ["npm", "install", "--verbose", "--production", "--prefix", server_path, server_path]
-        )
+        args = ["npm", "install", "--verbose", "--production", "--prefix", server_path, server_path]
+        if async_io:
+            run_command_async(args, self._on_install_success, self._on_error)
+        else:
+            output, error = run_command_sync(args)
+            self._on_error(error) if error is not None else self._on_install_success(output)
 
     def _on_install_success(self, _: str) -> None:
         self._is_ready = True
@@ -192,6 +153,7 @@ class ServerNpmResource:
             '{}: Server installed. Sublime Text restart might be required.'.format(self._package_name))
 
     def _on_error(self, error: str) -> None:
+        self._error_on_install = True
         self._stop_indicator()
         log_and_show_message('{}: Error:'.format(self._package_name), error)
 

--- a/st3/lsp_utils/server_npm_resource.py
+++ b/st3/lsp_utils/server_npm_resource.py
@@ -95,10 +95,6 @@ class ServerNpmResource:
     def dst_path(self) -> str:
         return os.path.join(self._package_storage, self._node_version, self._server_directory)
 
-    def cleanup(self) -> None:
-        if os.path.isdir(self._package_storage):
-            shutil.rmtree(self._package_storage)
-
     def needs_installation(self) -> bool:
         if self._initialized:
             return False


### PR DESCRIPTION
Instead of creating extra thread when installing server in ST4,
use "AbstractPlugin.needs_update_or_installation" and co.

The advantages are:
 - no extra threads
 - lazy installation - only starts when associated file is opened
 - does not require ST restart after server was installed

 Also, call "(un)register_plugin" as recommended by AbstractPlugin API.