### PR TITLE
Add PipClientHandler implementation

### DIFF
--- a/docs/source/client_handlers.rst
+++ b/docs/source/client_handlers.rst
@@ -10,3 +10,8 @@ NpmClientHandler
 ----------------
 
 .. autoclass:: lsp_utils.NpmClientHandler
+
+PipClientHandler
+----------------
+
+.. autoclass:: lsp_utils.PipClientHandler

--- a/docs/source/server_resource_handlers.rst
+++ b/docs/source/server_resource_handlers.rst
@@ -10,3 +10,8 @@ ServerResourceInterface
 -----------------------
 
 .. autoclass:: lsp_utils.ServerResourceInterface
+
+ServerPipResource
+-----------------
+
+.. autoclass:: lsp_utils.ServerPipResource

--- a/st3/lsp_utils/__init__.py
+++ b/st3/lsp_utils/__init__.py
@@ -4,6 +4,7 @@ from ._client_handler import request_handler
 from .api_wrapper_interface import ApiWrapperInterface
 from .generic_client_handler import GenericClientHandler
 from .npm_client_handler import NpmClientHandler
+from .pip_client_handler import PipClientHandler
 from .server_npm_resource import ServerNpmResource
 from .server_pip_resource import ServerPipResource
 from .server_resource_interface import ServerResourceInterface
@@ -14,6 +15,7 @@ __all__ = [
     'ClientHandler',
     'GenericClientHandler',
     'NpmClientHandler',
+    'PipClientHandler',
     'ServerResourceInterface',
     'ServerStatus'
     'ServerNpmResource',

--- a/st3/lsp_utils/__init__.py
+++ b/st3/lsp_utils/__init__.py
@@ -5,6 +5,7 @@ from .api_wrapper_interface import ApiWrapperInterface
 from .generic_client_handler import GenericClientHandler
 from .npm_client_handler import NpmClientHandler
 from .server_npm_resource import ServerNpmResource
+from .server_pip_resource import ServerPipResource
 from .server_resource_interface import ServerResourceInterface
 from .server_resource_interface import ServerStatus
 
@@ -16,6 +17,7 @@ __all__ = [
     'ServerResourceInterface',
     'ServerStatus'
     'ServerNpmResource',
+    'ServerPipResource',
     'notification_handler',
     'request_handler',
 ]

--- a/st3/lsp_utils/_client_handler/abstract_plugin.py
+++ b/st3/lsp_utils/_client_handler/abstract_plugin.py
@@ -135,10 +135,6 @@ class ClientHandler(AbstractPlugin, ClientHandlerInterface):
         }
 
     @classmethod
-    def get_storage_path(cls) -> str:
-        return cls.storage_path()
-
-    @classmethod
     def on_settings_read_internal(cls, settings: sublime.Settings) -> None:
         settings.set('enabled', True)
         languages = settings.get('languages', None)  # type: Optional[List[LanguagesDict]]

--- a/st3/lsp_utils/_client_handler/interface.py
+++ b/st3/lsp_utils/_client_handler/interface.py
@@ -42,11 +42,6 @@ class ClientHandlerInterface(metaclass=ABCMeta):
 
     @classmethod
     @abstractmethod
-    def get_storage_path(cls) -> str:
-        ...
-
-    @classmethod
-    @abstractmethod
     def get_additional_variables(cls) -> Dict[str, str]:
         ...
 

--- a/st3/lsp_utils/_client_handler/language_handler.py
+++ b/st3/lsp_utils/_client_handler/language_handler.py
@@ -117,7 +117,7 @@ class ClientHandler(LanguageHandler, ClientHandlerInterface):
 
             def perform_install() -> None:
                 try:
-                    message = '{}: Installing server in path: {}'.format(name, cls.get_storage_path())
+                    message = '{}: Installing server in path: {}'.format(name, cls.storage_path())
                     log_and_show_message(message, show_in_status=False)
                     with ActivityIndicator(sublime.active_window(), message):
                         server.install_or_update()
@@ -142,10 +142,6 @@ class ClientHandler(LanguageHandler, ClientHandlerInterface):
             'languages': [],
             'settings': {},
         }
-
-    @classmethod
-    def get_storage_path(cls) -> str:
-        return cls.storage_path()
 
     # --- Internals ---------------------------------------------------------------------------------------------------
 

--- a/st3/lsp_utils/generic_client_handler.py
+++ b/st3/lsp_utils/generic_client_handler.py
@@ -54,8 +54,19 @@ class GenericClientHandler(ClientHandler, metaclass=ABCMeta):
         return cls.package_name
 
     @classmethod
+    def storage_path(cls) -> str:
+        """
+        The storage path. Use this as your base directory to install server files. Its path is '$DATA/Package Storage'.
+        You should have an additional subdirectory preferrably the same name as your plugin. For instance:
+        """
+        return super().storage_path()
+
+    @classmethod
     def package_storage(cls) -> str:
-        return os.path.join(cls.get_storage_path(), cls.package_name)
+        """
+        The storage path for this package. Its path is '$DATA/Package Storage/[Package_Name]'.
+        """
+        return os.path.join(cls.storage_path(), cls.package_name)
 
     @classmethod
     def get_command(cls) -> List[str]:

--- a/st3/lsp_utils/npm_client_handler.py
+++ b/st3/lsp_utils/npm_client_handler.py
@@ -1,8 +1,7 @@
 from .generic_client_handler import GenericClientHandler
 from .server_npm_resource import ServerNpmResource
 from .server_resource_interface import ServerResourceInterface
-from abc import abstractproperty
-from LSP.plugin.core.typing import Any, Dict, List, Optional, Tuple
+from LSP.plugin.core.typing import Dict, List, Optional, Tuple
 import sublime
 
 __all__ = ['NpmClientHandler']

--- a/st3/lsp_utils/npm_client_handler.py
+++ b/st3/lsp_utils/npm_client_handler.py
@@ -91,7 +91,3 @@ class NpmClientHandler(GenericClientHandler):
         if cls.__server:
             return cls.__server.server_directory_path
         return ''
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        # Seems unnecessary to override but it's to hide the original argument from the documentation.
-        super().__init__(*args, **kwargs)

--- a/st3/lsp_utils/pip_client_handler.py
+++ b/st3/lsp_utils/pip_client_handler.py
@@ -1,0 +1,50 @@
+from .generic_client_handler import GenericClientHandler
+from .server_pip_resource import ServerPipResource
+from .server_resource_interface import ServerResourceInterface
+from LSP.plugin.core.typing import Any, Optional
+
+__all__ = ['PipClientHandler']
+
+
+class PipClientHandler(GenericClientHandler):
+    """
+    An implementation of :class:`GenericClientHandler` for handling pip-based LSP plugins.
+
+    Automatically manages a pip-based server by installing and updating dependencies based on provided
+    `requirements.txt` file.
+    """
+    __server = None  # type: Optional[ServerPipResource]
+
+    requirements_txt_path = ''
+    """
+    The full filesystem path to the `requirements.txt` file containing a list of dependencies required by the server.
+
+    The file format is `dependency_name==dependency_version` or just a direct path to the dependency (for example to
+    a github repo). For example:
+
+    .. code::
+
+        pyls==0.1.2
+        colorama==1.2.2
+        git+https://github.com/tomv564/pyls-mypy.git
+
+    :required: Yes
+    """
+
+    server_filename = ''
+    """
+    The file name of the binary used to start the server.
+
+    :required: Yes
+    """
+
+    @classmethod
+    def manages_server(cls) -> bool:
+        return True
+
+    @classmethod
+    def get_server(cls) -> Optional[ServerResourceInterface]:
+        if not cls.__server:
+            cls.__server = ServerPipResource(cls.storage_path(), cls.package_name, cls.requirements_txt_path,
+                                            cls.server_filename)
+        return cls.__server

--- a/st3/lsp_utils/pip_client_handler.py
+++ b/st3/lsp_utils/pip_client_handler.py
@@ -19,8 +19,7 @@ class PipClientHandler(GenericClientHandler):
     """
     The path to the `requirements.txt` file containing a list of dependencies required by the server.
 
-    If the package `LSP-foo` has a `requirements.txt` file at the root then the path will be
-    `Packages/LSP-foo/requirements.txt`.
+    If the package `LSP-foo` has a `requirements.txt` file at the root then the path will be just `requirements.txt`.
 
     The file format is `dependency_name==dependency_version` or just a direct path to the dependency (for example to
     a github repo). For example:

--- a/st3/lsp_utils/pip_client_handler.py
+++ b/st3/lsp_utils/pip_client_handler.py
@@ -17,7 +17,10 @@ class PipClientHandler(GenericClientHandler):
 
     requirements_txt_path = ''
     """
-    The full filesystem path to the `requirements.txt` file containing a list of dependencies required by the server.
+    The path to the `requirements.txt` file containing a list of dependencies required by the server.
+
+    If the package `LSP-foo` has a `requirements.txt` file at the root then the path will be
+    `Packages/LSP-foo/requirements.txt`.
 
     The file format is `dependency_name==dependency_version` or just a direct path to the dependency (for example to
     a github repo). For example:

--- a/st3/lsp_utils/server_pip_resource.py
+++ b/st3/lsp_utils/server_pip_resource.py
@@ -17,9 +17,8 @@ class ServerPipResource(ServerResourceInterface):
 
     :param storage_path: The path to the package storage (pass :meth:`lsp_utils.GenericClientHandler.storage_path()`)
     :param package_name: The package name (used as a directory name for storage)
-    :param requirements_path: The path to the `requirements.txt` file.
-           If the package `LSP-foo` has a `requirements.txt` file at the root then the path will be
-           `Packages/LSP-foo/requirements.txt`.
+    :param requirements_path: The path to the `requirements.txt` file, relative to the package directory.
+           If the package `LSP-foo` has a `requirements.txt` file at the root then the path will be `requirements.txt`.
     :param server_binary_filename: The name of the file used to start the server.
     """
 
@@ -42,7 +41,7 @@ class ServerPipResource(ServerResourceInterface):
                  server_binary_filename: str) -> None:
         self._storage_path = storage_path
         self._package_name = package_name
-        self._requirements_path = requirements_path
+        self._requirements_path = 'Packages/{}/{}'.format(self._package_name, requirements_path)
         self._server_binary_filename = server_binary_filename
         self._status = ServerStatus.UNINITIALIZED
 

--- a/st3/lsp_utils/server_pip_resource.py
+++ b/st3/lsp_utils/server_pip_resource.py
@@ -1,0 +1,113 @@
+from .helpers import run_command_sync
+from .server_resource_interface import ServerResourceInterface
+from .server_resource_interface import ServerStatus
+from LSP.plugin.core.typing import Dict, List, Optional, Tuple
+import os
+import shutil
+import sublime
+
+__all__ = ['ServerPipResource']
+
+
+class ServerPipResource(ServerResourceInterface):
+    """
+    An implementation of :class:`lsp_utils.ServerResourceInterface` implementing server management for
+    pip-based servers. Handles installation and updates of the server in the package storage.
+
+    :param storage_path: The path to the package storage (pass :meth:`lsp_utils.GenericClientHandler.storage_path()`)
+    :param package_name: The package name (used as a directory name for storage)
+    :param requirements_path: The file path to the requirements.txt file (in format: name==version).
+    """
+
+    @classmethod
+    def file_extension(cls) -> str:
+        return '.exe' if sublime.platform() == 'windows' else ''
+
+    @classmethod
+    def python_exe(cls) -> str:
+        return 'python' if sublime.platform() == 'windows' else 'python3'
+
+    @classmethod
+    def run(cls, *args, cwd: Optional[str] = None) -> str:
+        output, error = run_command_sync(list(args), cwd=cwd)
+        if error:
+            raise Exception(error)
+        return output
+
+    def __init__(self, storage_path: str, package_name: str, requirements_path: str) -> None:
+        self._storage_path = storage_path
+        self._package_name = package_name
+        self._requirements_path = requirements_path
+        self.requirements = self.parse_requirements(requirements_path)
+        self._status = ServerStatus.UNINITIALIZED
+
+    def parse_requirements(self, requirements_path: str) -> List[Tuple[str, Optional[str]]]:
+        requirements = []  # type: List[Tuple[str, Optional[str]]]
+        with open(requirements_path, 'r') as f:
+            for line in [line.strip() for line in f.readlines()]:
+                if line:
+                    parts = line.split('==')
+                    if len(parts) == 2:
+                        requirements.append(tuple(parts))
+                    elif len(parts) == 1:
+                        requirements.append((parts[0], None))
+        return requirements
+
+    def basedir(self) -> str:
+        return os.path.join(self._storage_path, self._package_name)
+
+    def bindir(self) -> str:
+        bin_dir = 'Scripts' if sublime.platform() == 'windows' else 'bin'
+        return os.path.join(self.basedir(), bin_dir)
+
+    def server_exe(self) -> str:
+        return os.path.join(self.bindir(), 'pyls' + self.file_extension())
+
+    def pip_exe(self) -> str:
+        return os.path.join(self.bindir(), 'pip' + self.file_extension())
+
+    def python_version(self) -> str:
+        return os.path.join(self.basedir(), 'python_version')
+
+    # --- ServerResourceInterface handlers ----------------------------------------------------------------------------
+
+    @property
+    def binary_path(self) -> str:
+        return self.server_exe()
+
+    def needs_installation(self) -> bool:
+        if os.path.exists(self.server_exe()) and os.path.exists(self.pip_exe()):
+            if not os.path.exists(self.python_version()):
+                return True
+            with open(self.python_version(), 'r') as f:
+                if f.readline().strip() != self.run(self.python_exe(), '--version').strip():
+                    print('DFIFF')
+                    return True
+            for line in self.run(self.pip_exe(), 'freeze').splitlines():
+                for requirement, version in self.requirements:
+                    if not version:
+                        continue
+                    prefix = requirement + '=='
+                    if line.startswith(prefix):
+                        stored_version_str = line[len(prefix):].strip()
+                        if stored_version_str != version:
+                            return True
+            self._status = ServerStatus.READY
+            return False
+        return True
+
+    def install_or_update(self) -> None:
+        shutil.rmtree(self.basedir(), ignore_errors=True)
+        try:
+            os.makedirs(self.basedir(), exist_ok=True)
+            self.run(self.python_exe(), '-m', 'venv', self._package_name, cwd=self._storage_path)
+            self.run(self.pip_exe(), 'install', '-r', self._requirements_path, '--disable-pip-version-check')
+            with open(self.python_version(), 'w') as f:
+                f.write(self.run(self.python_exe(), '--version'))
+        except Exception:
+            shutil.rmtree(self.basedir(), ignore_errors=True)
+            raise
+        self._status = ServerStatus.READY
+
+    def get_status(self) -> int:
+        return self._status


### PR DESCRIPTION
This is a client handler and server resource implementation that manages a pip-based server from dependencies provided through "requirements.txt" file.

There is no support for overriding versions of dependencies because I don't see a need for it.

Also:
 - remote "GenericClientHandler.get_storage_path()" API and just use  "GenericClientHanlder.storage_path()" instead which is provided by both AbstractPlugin and LanguageHandler
 - Document storage_path() and package_storage() of GenericClientHandler