### PR TITLE
Require importing PipClientHandler from its file

### DIFF
--- a/docs/source/client_handlers.rst
+++ b/docs/source/client_handlers.rst
@@ -14,4 +14,4 @@ NpmClientHandler
 PipClientHandler
 ----------------
 
-.. autoclass:: lsp_utils.PipClientHandler
+.. autoclass:: lsp_utils.pip_client_handler.PipClientHandler

--- a/st3/lsp_utils/__init__.py
+++ b/st3/lsp_utils/__init__.py
@@ -4,7 +4,6 @@ from ._client_handler import request_handler
 from .api_wrapper_interface import ApiWrapperInterface
 from .generic_client_handler import GenericClientHandler
 from .npm_client_handler import NpmClientHandler
-from .pip_client_handler import PipClientHandler
 from .server_npm_resource import ServerNpmResource
 from .server_pip_resource import ServerPipResource
 from .server_resource_interface import ServerResourceInterface
@@ -15,9 +14,8 @@ __all__ = [
     'ClientHandler',
     'GenericClientHandler',
     'NpmClientHandler',
-    'PipClientHandler',
     'ServerResourceInterface',
-    'ServerStatus'
+    'ServerStatus',
     'ServerNpmResource',
     'ServerPipResource',
     'notification_handler',


### PR DESCRIPTION
Not exporting from the main `lsp_utils` export as importing the class
but not using it anywhere would trigger an error when LSP would try
to call class methods of such class.