### PR TITLE
Add ActivityIndicator that works on the main thread

### DIFF
--- a/st3/lsp_utils/__init__.py
+++ b/st3/lsp_utils/__init__.py
@@ -1,6 +1,7 @@
 from ._client_handler import ClientHandler
 from ._client_handler import notification_handler
 from ._client_handler import request_handler
+from .activity_indicator import ActivityIndicator
 from .api_wrapper_interface import ApiWrapperInterface
 from .generic_client_handler import GenericClientHandler
 from .npm_client_handler import NpmClientHandler
@@ -10,6 +11,7 @@ from .server_resource_interface import ServerResourceInterface
 from .server_resource_interface import ServerStatus
 
 __all__ = [
+    'ActivityIndicator',
     'ApiWrapperInterface',
     'ClientHandler',
     'GenericClientHandler',

--- a/st3/lsp_utils/activity_indicator.py
+++ b/st3/lsp_utils/activity_indicator.py
@@ -66,7 +66,7 @@ class ActivityIndicator:
         target: Union[StatusTarget, sublime.View, sublime.Window],
         label: Optional[str] = None,
     ) -> None:
-        self.label = label
+        self._label = label
 
         if isinstance(target, sublime.View):
             self._target = ViewTarget(target)
@@ -99,7 +99,7 @@ class ActivityIndicator:
             raise ValueError('Timer is already running')
         else:
             self._state = True
-            self.update()
+            self._update()
             sublime.set_timeout(self._run)
 
     def stop(self) -> None:
@@ -111,25 +111,29 @@ class ActivityIndicator:
         self._state = False
         self._target.clear()
 
+    def set_label(self, label: str) -> None:
+        self._label = label
+        self._update()
+
     def _run(self) -> None:
         if self._state:
-            sublime.set_timeout(self.tick, self.interval)
+            sublime.set_timeout(self._tick, self.interval)
 
-    def tick(self) -> None:
+    def _tick(self) -> None:
         self._ticks += 1
-        self.update()
+        self._update()
         self._run()
 
-    def update(self) -> None:
-        self._target.set(self.render(self._ticks))
+    def _update(self) -> None:
+        self._target.set(self._render(self._ticks))
 
-    def render(self, ticks: int) -> str:
+    def _render(self, ticks: int) -> str:
         status = ticks % (2 * self.width)
         before = min(status, (2 * self.width) - status)
         after = self.width - before
 
         return "{}[{}={}]".format(
-            self.label + ' ' if self.label else '',
+            self._label + ' ' if self._label else '',
             " " * before,
             " " * after,
         )

--- a/st3/lsp_utils/activity_indicator.py
+++ b/st3/lsp_utils/activity_indicator.py
@@ -1,0 +1,135 @@
+from abc import ABCMeta, abstractmethod
+from LSP.plugin.core.typing import Optional, Union
+from types import TracebackType
+from uuid import uuid4
+import sublime
+
+
+__all__ = ['ActivityIndicator']
+
+
+class StatusTarget(metaclass=ABCMeta):
+    @abstractmethod
+    def set(self, message: str) -> None:
+        ...
+
+    @abstractmethod
+    def clear(self) -> None:
+        ...
+
+
+class WindowTarget(StatusTarget):
+    def __init__(self, window: sublime.Window) -> None:
+        self.window = window
+
+    def set(self, message: str) -> None:
+        self.window.status_message(message)
+
+    def clear(self) -> None:
+        self.window.status_message("")
+
+
+class ViewTarget(StatusTarget):
+    def __init__(self, view: sublime.View, key: Optional[str] = None) -> None:
+        self.view = view
+        if key is None:
+            self.key = '_{!s}'.format(uuid4())
+        else:
+            self.key = key
+
+    def set(self, message: str) -> None:
+        self.view.set_status(self.key, message)
+
+    def clear(self) -> None:
+        self.view.erase_status(self.key)
+
+
+class ActivityIndicator:
+    """
+    An animated text-based indicator to show that some activity is in progress.
+
+    The `target` argument should be a :class:`sublime.View` or :class:`sublime.Window`.
+    The indicator will be shown in the status bar of that view or window.
+    If `label` is provided, then it will be shown next to the animation.
+
+    :class:`ActivityIndicator` can be used as a context manager.
+
+    .. versionadded:: 1.4
+    """
+    width = 10  # type: int
+    interval = 100  # type: float
+
+    _target = None  # type: Optional[StatusTarget]
+
+    def __init__(
+        self,
+        target: Union[StatusTarget, sublime.View, sublime.Window],
+        label: Optional[str] = None,
+    ) -> None:
+        self.label = label
+
+        if isinstance(target, sublime.View):
+            self._target = ViewTarget(target)
+        elif isinstance(target, sublime.Window):
+            self._target = WindowTarget(target)
+        else:
+            self._target = target
+
+        self._ticks = 0
+        self._state = False
+
+    def __enter__(self) -> None:
+        self.start()
+
+    def __exit__(
+        self,
+        exc_type: type,
+        exc_value: Exception,
+        traceback: TracebackType
+    ) -> None:
+        self.stop()
+
+    def start(self) -> None:
+        """
+        Start displaying the indicator and animate it.
+
+        :raise ValueError: if the indicator is already running.
+        """
+        if self._state:
+            raise ValueError('Timer is already running')
+        else:
+            self._state = True
+            self.update()
+            sublime.set_timeout(self._run)
+
+    def stop(self) -> None:
+        """
+        Stop displaying the indicator.
+
+        If the indicator is not running, do nothing.
+        """
+        self._state = False
+        self._target.clear()
+
+    def _run(self) -> None:
+        if self._state:
+            sublime.set_timeout(self.tick, self.interval)
+
+    def tick(self) -> None:
+        self._ticks += 1
+        self.update()
+        self._run()
+
+    def update(self) -> None:
+        self._target.set(self.render(self._ticks))
+
+    def render(self, ticks: int) -> str:
+        status = ticks % (2 * self.width)
+        before = min(status, (2 * self.width) - status)
+        after = self.width - before
+
+        return "{}[{}={}]".format(
+            self.label + ' ' if self.label else '',
+            " " * before,
+            " " * after,
+        )

--- a/st3/lsp_utils/activity_indicator.py
+++ b/st3/lsp_utils/activity_indicator.py
@@ -100,7 +100,7 @@ class ActivityIndicator:
         else:
             self._state = True
             self._update()
-            sublime.set_timeout(self._run)
+            self._run()
 
     def stop(self) -> None:
         """


### PR DESCRIPTION
A main-thread variant of the `ActivityIndicator` from `sublime_lib`.

Relates to https://github.com/sublimelsp/LSP-pyright/issues/36