### PR TITLE
fix: activity indicator still shows after being stopped

### DIFF
--- a/st3/lsp_utils/activity_indicator.py
+++ b/st3/lsp_utils/activity_indicator.py
@@ -118,20 +118,20 @@ class ActivityIndicator:
         :param label: The new label text
         """
         self._label = label
-        self._update()
+        if self._state:
+            self._update()
 
     def _run(self) -> None:
-        if self._state:
-            sublime.set_timeout(self._tick, self.interval)
+        sublime.set_timeout(self._tick, self.interval)
 
     def _tick(self) -> None:
-        self._ticks += 1
-        self._update()
-        self._run()
+        if self._state:
+            self._ticks += 1
+            self._update()
+            self._run()
 
     def _update(self) -> None:
-        if self._state:
-            self._target.set(self._render(self._ticks))
+        self._target.set(self._render(self._ticks))
 
     def _render(self, ticks: int) -> str:
         status = ticks % (2 * self.width)

--- a/st3/lsp_utils/activity_indicator.py
+++ b/st3/lsp_utils/activity_indicator.py
@@ -130,7 +130,8 @@ class ActivityIndicator:
         self._run()
 
     def _update(self) -> None:
-        self._target.set(self._render(self._ticks))
+        if self._state:
+            self._target.set(self._render(self._ticks))
 
     def _render(self, ticks: int) -> str:
         status = ticks % (2 * self.width)


### PR DESCRIPTION
If `stop()` is called between `sublime.set_timeout(self._tick, self.interval)` and `_update()` (there is a 100ms interval between these two calls), `self._target.clear()` will be called first from `stop()` and then `self._target.set(self._render(self._ticks))` from `_update()`.

This results in the message gets "stucked" in the status bar.

---

Fixes https://github.com/sublimelsp/lsp_utils/issues/48