### PR TITLE
fix: installation failed with NPM 7

### DIFF
--- a/st3/lsp_utils/server_npm_resource.py
+++ b/st3/lsp_utils/server_npm_resource.py
@@ -115,8 +115,8 @@ class ServerNpmResource(ServerResourceInterface):
         if dependencies_installed:
             self._status = ServerStatus.READY
         else:
-            args = ["npm", "install", "--verbose", "--production", "--prefix", self._server_dest, self._server_dest]
-            output, error = run_command_sync(args)
+            args = ["npm", "install", "--verbose", "--production"]
+            output, error = run_command_sync(args, cwd=self._server_dest)
             if error is not None:
                 self._status = ServerStatus.ERROR
                 raise Exception(error)


### PR DESCRIPTION
Not sure why the `--prefix` seems not being respected in NPM 7. But we can change CWD when executing a shell command as a general solution anyway. Tested working both on NPM 6 & 7.

Related:
- https://discord.com/channels/280102180189634562/645268178397560865/811556998008012832
- https://discord.com/channels/280102180189634562/645268178397560865/813138879983910991