### PR TITLE
Fix issues with cyclic references and plugin instances not being GC'ed

### DIFF
--- a/st3/lsp_utils/_client_handler/abstract_plugin.py
+++ b/st3/lsp_utils/_client_handler/abstract_plugin.py
@@ -2,6 +2,7 @@ from ..api_wrapper_interface import ApiWrapperInterface
 from ..server_resource_interface import ServerStatus
 from .api_decorator import register_decorated_handlers
 from .interface import ClientHandlerInterface
+from functools import partial
 from LSP.plugin import AbstractPlugin
 from LSP.plugin import ClientConfig
 from LSP.plugin import Notification
@@ -12,6 +13,7 @@ from LSP.plugin import unregister_plugin
 from LSP.plugin import WorkspaceFolder
 from LSP.plugin.core.rpc import method2attr
 from LSP.plugin.core.typing import Any, Callable, Dict, List, Optional, Tuple, TypedDict
+from weakref import ref
 import sublime
 
 __all__ = ['ClientHandler']
@@ -22,35 +24,46 @@ LanguagesDict = TypedDict('LanguagesDict', {
     'scopes': Optional[List[str]],
     'syntaxes': Optional[List[str]],
 }, total=False)
+ApiRequestHandler = Callable[[Any, Callable[[Any], None]], None]
 
 
 class ApiWrapper(ApiWrapperInterface):
-    def __init__(self, plugin: AbstractPlugin):
+    def __init__(self, plugin: 'ref[AbstractPlugin]'):
         self.__plugin = plugin
+
+    def __session(self):
+        plugin = self.__plugin()
+        return plugin.weaksession() if plugin else None
 
     # --- ApiWrapperInterface -----------------------------------------------------------------------------------------
 
     def on_notification(self, method: str, handler: Callable[[Any], None]) -> None:
-        setattr(self.__plugin, method2attr(method), lambda params: handler(params))
+        plugin = self.__plugin()
+        if plugin:
+            setattr(plugin, method2attr(method), lambda params: handler(params))
 
-    def on_request(self, method: str, handler: Callable[[Any, Callable[[Any], None]], None]) -> None:
+    def on_request(self, method: str, handler: ApiRequestHandler) -> None:
         def send_response(request_id: Any, result: Any) -> None:
-            session = self.__plugin.weaksession()
+            session = self.__session()
             if session:
                 session.send_response(Response(request_id, result))
 
-        def on_response(params: Any, request_id: Any) -> None:
-            handler(params, lambda result: send_response(request_id, result))
+        def on_response(handler_ref: 'ref[ApiRequestHandler]', params: Any, request_id: Any) -> None:
+            handler = handler_ref()
+            if handler:
+                handler(params, lambda result: send_response(request_id, result))
 
-        setattr(self.__plugin, method2attr(method), on_response)
+        plugin = self.__plugin()
+        if plugin:
+            setattr(plugin, method2attr(method), partial(on_response, ref(handler)))
 
     def send_notification(self, method: str, params: Any) -> None:
-        session = self.__plugin.weaksession()
+        session = self.__session()
         if session:
             session.send_notification(Notification(method, params))
 
     def send_request(self, method: str, params: Any, handler: Callable[[Any, bool], None]) -> None:
-        session = self.__plugin.weaksession()
+        session = self.__session()
         if session:
             session.send_request(
                 Request(method, params), lambda result: handler(result, False), lambda result: handler(result, True))
@@ -160,6 +173,6 @@ class ClientHandler(AbstractPlugin, ClientHandlerInterface):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        api = ApiWrapper(self)
+        api = ApiWrapper(ref(self))
         register_decorated_handlers(self, api)
         self.on_ready(api)

--- a/st3/lsp_utils/_util/__init__.py
+++ b/st3/lsp_utils/_util/__init__.py
@@ -1,0 +1,5 @@
+from .weak_method import weak_method
+
+__all__ = [
+    'weak_method',
+]

--- a/st3/lsp_utils/_util/weak_method.py
+++ b/st3/lsp_utils/_util/weak_method.py
@@ -1,0 +1,32 @@
+from LSP.plugin.core.typing import Any, Callable
+from types import MethodType
+import weakref
+
+
+__all__ = ['weak_method']
+
+
+# An implementation of weak method borrowed from sublime_lib [1]
+#
+# We need it to be able to weak reference bound methods as `weakref.WeakMethod` is not available in
+# 3.3 runtime.
+#
+# The reason this is necessary is explained in the documentation of `weakref.WeakMethod`:
+# > A custom ref subclass which simulates a weak reference to a bound method (i.e., a method defined
+# > on a class and looked up on an instance). Since a bound method is ephemeral, a standard weak
+# > reference cannot keep hold of it.
+#
+# [1] https://github.com/SublimeText/sublime_lib/blob/master/st3/sublime_lib/_util/weak_method.py
+
+def weak_method(method: Callable) -> Callable:
+    assert isinstance(method, MethodType)
+    self_ref = weakref.ref(method.__self__)
+    function_ref = weakref.ref(method.__func__)
+
+    def wrapped(*args: Any, **kwargs: Any) -> Any:
+        self = self_ref()
+        function = function_ref()
+        if self is not None and function is not None:
+            return function(self, *args, **kwargs)
+
+    return wrapped

--- a/st3/lsp_utils/_util/weak_method.py
+++ b/st3/lsp_utils/_util/weak_method.py
@@ -26,7 +26,9 @@ def weak_method(method: Callable) -> Callable:
     def wrapped(*args: Any, **kwargs: Any) -> Any:
         self = self_ref()
         function = function_ref()
-        if self is not None and function is not None:
-            return function(self, *args, **kwargs)
+        if self is None or function is None:
+            print('[lsp_utils] Error: weak_method not called due to a deleted reference', [self, function])
+            return
+        return function(self, *args, **kwargs)
 
     return wrapped


### PR DESCRIPTION
ApiWrapper receives a weak reference to the plugin instance to break the
cyclic dependency.

The handler passed to ApiWrapper methods that create API handlers
is only referenced weakly.

Fixes #55