### PR TITLE
Make npm server install more robust

### DIFF
--- a/st3/lsp_utils/node_runtime.py
+++ b/st3/lsp_utils/node_runtime.py
@@ -7,6 +7,7 @@ from .helpers import version_to_string
 from contextlib import contextmanager
 from LSP.plugin.core.typing import List, Optional, Tuple
 from os import path
+from os import remove
 import os
 import shutil
 import sublime
@@ -143,9 +144,13 @@ class NodeRuntimeLocal(NodeRuntime):
         self._base_dir = path.abspath(path.join(base_dir, node_version))
         self._node_version = node_version
         self._node_dir = path.join(self._base_dir, 'node')
+        self._install_in_progress_marker_file = path.join(self._base_dir, '.installing')
         self.resolve_paths()
 
     def resolve_paths(self) -> None:
+        if path.isfile(self._install_in_progress_marker_file):
+            # Will trigger re-installation.
+            return
         self._node = self.resolve_binary()
         self._node_lib = self.resolve_lib()
         self._npm = path.join(self._node_lib, 'npm', 'bin', 'npm-cli.js')
@@ -170,10 +175,15 @@ class NodeRuntimeLocal(NodeRuntime):
         return [self._node, self._npm]
 
     def install_node(self) -> None:
+        os.makedirs(self._base_dir)
+        with open(self._install_in_progress_marker_file, 'a'):
+            pass
         with ActivityIndicator(sublime.active_window(), 'Installing Node.js'):
             install_node = InstallNode(self._base_dir, self._node_version)
             install_node.run()
             self.resolve_paths()
+        remove(self._install_in_progress_marker_file)
+        self.resolve_paths()
 
 
 class InstallNode:
@@ -241,7 +251,7 @@ class InstallNode:
         except Exception as ex:
             raise ex
         finally:
-            os.remove(archive)
+            remove(archive)
 
 
 @contextmanager

--- a/st3/lsp_utils/node_runtime.py
+++ b/st3/lsp_utils/node_runtime.py
@@ -175,9 +175,8 @@ class NodeRuntimeLocal(NodeRuntime):
         return [self._node, self._npm]
 
     def install_node(self) -> None:
-        os.makedirs(self._base_dir)
-        with open(self._install_in_progress_marker_file, 'a'):
-            pass
+        os.makedirs(os.path.dirname(self._install_in_progress_marker_file), exist_ok=True)
+        open(self._install_in_progress_marker_file, 'a').close()
         with ActivityIndicator(sublime.active_window(), 'Installing Node.js'):
             install_node = InstallNode(self._base_dir, self._node_version)
             install_node.run()

--- a/st3/lsp_utils/server_npm_resource.py
+++ b/st3/lsp_utils/server_npm_resource.py
@@ -84,7 +84,7 @@ class ServerNpmResource(ServerResourceInterface):
 
     def install_or_update(self) -> None:
         try:
-            makedirs(self._server_dest, exist_ok=True)
+            makedirs(path.dirname(self._installation_marker_file), exist_ok=True)
             with open(self._installation_marker_file, 'a'):
                 pass
             if path.isdir(self._server_dest):

--- a/st3/lsp_utils/server_npm_resource.py
+++ b/st3/lsp_utils/server_npm_resource.py
@@ -85,8 +85,7 @@ class ServerNpmResource(ServerResourceInterface):
     def install_or_update(self) -> None:
         try:
             makedirs(path.dirname(self._installation_marker_file), exist_ok=True)
-            with open(self._installation_marker_file, 'a'):
-                pass
+            open(self._installation_marker_file, 'a').close()
             if path.isdir(self._server_dest):
                 shutil.rmtree(self._server_dest)
             ResourcePath(self._server_src).copytree(self._server_dest, exist_ok=True)

--- a/st3/lsp_utils/server_npm_resource.py
+++ b/st3/lsp_utils/server_npm_resource.py
@@ -4,7 +4,9 @@ from .server_resource_interface import ServerResourceInterface
 from .server_resource_interface import ServerStatus
 from hashlib import md5
 from LSP.plugin.core.typing import Dict, Optional
+from os import makedirs
 from os import path
+from os import remove
 from sublime_lib import ResourcePath
 import shutil
 
@@ -39,6 +41,7 @@ class ServerNpmResource(ServerResourceInterface):
         node_version = version_to_string(node_runtime.resolve_version())
         self._server_dest = path.join(package_storage, node_version, server_directory)
         self._binary_path = path.join(package_storage, node_version, server_binary_path)
+        self._installation_marker_file = path.join(package_storage, node_version, '.installing')
         self._node_runtime = node_runtime
 
     @property
@@ -64,12 +67,12 @@ class ServerNpmResource(ServerResourceInterface):
     def needs_installation(self) -> bool:
         installed = False
         if path.isdir(path.join(self._server_dest, 'node_modules')):
-            # Server already installed. Check if version has changed.
+            # Server already installed. Check if version has changed or last installation did not complete.
             try:
                 src_hash = md5(ResourcePath(self._server_src, 'package.json').read_bytes()).hexdigest()
                 with open(path.join(self._server_dest, 'package.json'), 'rb') as file:
                     dst_hash = md5(file.read()).hexdigest()
-                if src_hash == dst_hash:
+                if src_hash == dst_hash and not path.isfile(self._installation_marker_file):
                     installed = True
             except FileNotFoundError:
                 # Needs to be re-installed.
@@ -80,13 +83,18 @@ class ServerNpmResource(ServerResourceInterface):
         return True
 
     def install_or_update(self) -> None:
-        shutil.rmtree(self._server_dest, ignore_errors=True)
-        ResourcePath(self._server_src).copytree(self._server_dest, exist_ok=True)
-        dependencies_installed = path.isdir(path.join(self._server_dest, 'node_modules'))
-        if not dependencies_installed:
-            try:
+        try:
+            makedirs(self._server_dest, exist_ok=True)
+            with open(self._installation_marker_file, 'a'):
+                pass
+            if path.isdir(self._server_dest):
+                shutil.rmtree(self._server_dest)
+            ResourcePath(self._server_src).copytree(self._server_dest, exist_ok=True)
+            dependencies_installed = path.isdir(path.join(self._server_dest, 'node_modules'))
+            if not dependencies_installed:
                 self._node_runtime.npm_install(self._server_dest)
-            except Exception as error:
-                self._status = ServerStatus.ERROR
-                raise Exception(error)
+            remove(self._installation_marker_file)
+        except Exception as error:
+            self._status = ServerStatus.ERROR
+            raise Exception('Error installing the server:\n{}'.format(error))
         self._status = ServerStatus.READY


### PR DESCRIPTION
Before the server installation we'll create a marker file that will
only be removed on successful installation. So if the installation is
interrupted by closing ST or otherwise we'll not end up with a broken
installation that will then require re-installing the plugin.