### PR TITLE
slightly fix the required/installed requirement comparing

### DIFF
--- a/st3/lsp_utils/server_pip_resource.py
+++ b/st3/lsp_utils/server_pip_resource.py
@@ -10,7 +10,7 @@ import sublime
 __all__ = ['ServerPipResource']
 
 
-def parse_requirements_file(content: str) -> Dict[str, Optional[str]]:
+def parse_requirements(content: str) -> Dict[str, Optional[str]]:
     requirements = {}  # type: Dict[str, Optional[str]]
     lines = [line.strip() for line in content.splitlines()]
     for line in lines:
@@ -87,8 +87,8 @@ class ServerPipResource(ServerResourceInterface):
             with open(self.python_version(), 'r') as f:
                 if f.readline().strip() != self.run(self.python_exe(), '--version').strip():
                     return True
-            installed_requirements = parse_requirements_file(self.run(self.pip_exe(), 'freeze'))
-            requirements = parse_requirements_file(ResourcePath(self._requirements_path).read_text())
+            installed_requirements = parse_requirements(self.run(self.pip_exe(), 'freeze'))
+            requirements = parse_requirements(ResourcePath(self._requirements_path).read_text())
             for name, version in requirements.items():
                 if name not in installed_requirements:
                     # Has new requirement


### PR DESCRIPTION
The logic was quite broken.
 - there was no checking if new requirement was added
 - comparing pylsp version didn't work because it's listed as `python-lsp-server[all]` in requirements.txt but in `pip freeze` output there are individual modules rather than the `[all]` meta module. Added a hack for that that just removes `[all]` before checking.