### PR TITLE
Be louder about failing to resolve node runtime

### DIFF
--- a/st3/lsp_utils/node_runtime.py
+++ b/st3/lsp_utils/node_runtime.py
@@ -62,6 +62,9 @@ class NodeRuntime:
                     except Exception as ex:
                         message = 'Ignoring system Node.js runtime due to an error. {}'.format(ex)
                         log_and_show_message('{}: Error: {}'.format(package_name, message))
+                else:
+                    message = 'The system Node.js does not meet the requirements: {}'.format(node_runtime)
+                    log_and_show_message('{}: {}'.format(package_name, message))
             elif runtime == 'local':
                 node_runtime = NodeRuntimeLocal(path.join(storage_path, 'lsp_utils', 'node-runtime'))
                 if not node_runtime.meets_requirements():

--- a/st3/lsp_utils/server_npm_resource.py
+++ b/st3/lsp_utils/server_npm_resource.py
@@ -3,7 +3,7 @@ from .node_runtime import NodeRuntime
 from .server_resource_interface import ServerResourceInterface
 from .server_resource_interface import ServerStatus
 from hashlib import md5
-from LSP.plugin.core.typing import Dict, Optional
+from LSP.plugin.core.typing import Dict
 from os import makedirs
 from os import path
 from os import remove

--- a/st3/lsp_utils/server_npm_resource.py
+++ b/st3/lsp_utils/server_npm_resource.py
@@ -20,7 +20,7 @@ class ServerNpmResource(ServerResourceInterface):
     """
 
     @classmethod
-    def create(cls, options: Dict) -> Optional['ServerNpmResource']:
+    def create(cls, options: Dict) -> 'ServerNpmResource':
         package_name = options['package_name']
         server_directory = options['server_directory']
         server_binary_path = options['server_binary_path']
@@ -28,9 +28,9 @@ class ServerNpmResource(ServerResourceInterface):
         storage_path = options['storage_path']
         minimum_node_version = options['minimum_node_version']
         node_runtime = NodeRuntime.get(package_name, storage_path, minimum_node_version)
-        if node_runtime:
-            return ServerNpmResource(package_name, server_directory, server_binary_path, package_storage, node_runtime)
-        return None
+        if not node_runtime:
+            raise Exception('Failed resolving the Node Runtime. Please see Sublime Text console for more information')
+        return ServerNpmResource(package_name, server_directory, server_binary_path, package_storage, node_runtime)
 
     def __init__(self, package_name: str, server_directory: str, server_binary_path: str,
                  package_storage: str, node_runtime: NodeRuntime) -> None:


### PR DESCRIPTION
In some cases failure to resolve node runtime would only result in
a brief message in the status bar and server not starting. Make the
failure more obvious by raising an exception that will result in
disabling the client and showing an error.