### PR TITLE
Add an option to skip "npm install" for npm servers

### DIFF
--- a/st3/lsp_utils/npm_client_handler.py
+++ b/st3/lsp_utils/npm_client_handler.py
@@ -29,6 +29,13 @@ class NpmClientHandler(GenericClientHandler):
     :required: Yes
     """
 
+    skip_npm_install = False
+    """
+    Whether to skip the step that runs "npm install" in case the server doesn't need any dependencies.
+
+    :required: No
+    """
+
     # --- NpmClientHandler handlers -----------------------------------------------------------------------------------
 
     @classmethod
@@ -90,6 +97,7 @@ class NpmClientHandler(GenericClientHandler):
                 'package_storage': cls.package_storage(),
                 'minimum_node_version': cls.minimum_node_version(),
                 'storage_path': cls.storage_path(),
+                'skip_npm_install': cls.skip_npm_install,
             })
         return cls.__server
 

--- a/st3/lsp_utils/server_npm_resource.py
+++ b/st3/lsp_utils/server_npm_resource.py
@@ -76,8 +76,11 @@ class ServerNpmResource(ServerResourceInterface):
         installed = False
         if self._skip_npm_install or path.isdir(path.join(self._server_dest, 'node_modules')):
             # Server already installed. Check if version has changed or last installation did not complete.
+            src_package_json = ResourcePath(self._server_src, 'package.json')
+            if not src_package_json.exists():
+                raise Exception('Missing required "package.json" in {}'.format(self._server_src))
+            src_hash = md5(src_package_json.read_bytes()).hexdigest()
             try:
-                src_hash = md5(ResourcePath(self._server_src, 'package.json').read_bytes()).hexdigest()
                 with open(path.join(self._server_dest, 'package.json'), 'rb') as file:
                     dst_hash = md5(file.read()).hexdigest()
                 if src_hash == dst_hash and not path.isfile(self._installation_marker_file):


### PR DESCRIPTION
Some servers, like the new version of stylelint, bundle all dependencies
and don't need to have any dependencies installed.

This is needed because having no dependencies defined results in
no "node_modules" being created and messes up the logic that detects
if the server is installed or not.