### PR TITLE
Don't mutate plugin settings

### DIFF
--- a/st3/lsp_utils/_client_handler/abstract_plugin.py
+++ b/st3/lsp_utils/_client_handler/abstract_plugin.py
@@ -149,20 +149,6 @@ class ClientHandler(AbstractPlugin, ClientHandlerInterface):
         super().cleanup()
 
     @classmethod
-    def get_default_settings_schema(cls) -> Dict[str, Any]:
-        return {
-            'auto_complete_selector': '',
-            'command': [],
-            'enabled': True,
-            'env': {},
-            'experimental_capabilities': {},
-            'ignore_server_trigger_chars': False,
-            'initializationOptions': {},
-            'languages': [],
-            'settings': {},
-        }
-
-    @classmethod
     def on_settings_read_internal(cls, settings: sublime.Settings) -> None:
         languages = settings.get('languages', None)  # type: Optional[List[LanguagesDict]]
         if languages:

--- a/st3/lsp_utils/_client_handler/abstract_plugin.py
+++ b/st3/lsp_utils/_client_handler/abstract_plugin.py
@@ -148,30 +148,7 @@ class ClientHandler(AbstractPlugin, ClientHandlerInterface):
         unregister_plugin(cls)
         super().cleanup()
 
-    @classmethod
-    def on_settings_read_internal(cls, settings: sublime.Settings) -> None:
-        languages = settings.get('languages', None)  # type: Optional[List[LanguagesDict]]
-        if languages:
-            settings.set('languages', cls._upgrade_languages_list(languages))
-
     # --- Internals ---------------------------------------------------------------------------------------------------
-
-    @classmethod
-    def _upgrade_languages_list(cls, languages: List[LanguagesDict]) -> List[LanguagesDict]:
-        upgraded_list = []
-        for language in languages:
-            if 'document_selector' in language:
-                language.pop('scopes', None)
-                language.pop('syntaxes', None)
-                upgraded_list.append(language)
-            elif 'scopes' in language:
-                upgraded_list.append({
-                    'languageId': language.get('languageId'),
-                    'document_selector': ' | '.join(language['scopes'] or []),
-                })
-            else:
-                upgraded_list.append(language)
-        return upgraded_list
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)

--- a/st3/lsp_utils/_client_handler/interface.py
+++ b/st3/lsp_utils/_client_handler/interface.py
@@ -5,7 +5,7 @@ from abc import abstractmethod
 from LSP.plugin import ClientConfig
 from LSP.plugin import DottedDict
 from LSP.plugin import WorkspaceFolder
-from LSP.plugin.core.typing import Any, Dict, List, Optional, Tuple
+from LSP.plugin.core.typing import Dict, List, Optional, Tuple
 import sublime
 
 __all__ = ['ClientHandlerInterface']
@@ -13,11 +13,6 @@ __all__ = ['ClientHandlerInterface']
 
 class ClientHandlerInterface(metaclass=ABCMeta):
     package_name = ''
-
-    @classmethod
-    @abstractmethod
-    def get_default_settings_schema(cls) -> Dict[str, Any]:
-        ...
 
     @classmethod
     @abstractmethod

--- a/st3/lsp_utils/_client_handler/interface.py
+++ b/st3/lsp_utils/_client_handler/interface.py
@@ -89,11 +89,6 @@ class ClientHandlerInterface(metaclass=ABCMeta):
 
     @classmethod
     @abstractmethod
-    def on_client_configuration_ready(cls, configuration: Dict) -> None:
-        ...
-
-    @classmethod
-    @abstractmethod
     def is_allowed_to_start(
         cls,
         window: sublime.Window,

--- a/st3/lsp_utils/_client_handler/interface.py
+++ b/st3/lsp_utils/_client_handler/interface.py
@@ -79,10 +79,6 @@ class ClientHandlerInterface(metaclass=ABCMeta):
         ...
 
     @classmethod
-    def on_settings_read_internal(cls, settings: sublime.Settings) -> None:
-        pass
-
-    @classmethod
     @abstractmethod
     def is_allowed_to_start(
         cls,

--- a/st3/lsp_utils/_client_handler/language_handler.py
+++ b/st3/lsp_utils/_client_handler/language_handler.py
@@ -151,6 +151,8 @@ class ClientHandler(LanguageHandler, ClientHandlerInterface):
         super().cleanup()
         cls._setup_called = False
 
+    # --- Internals ---------------------------------------------------------------------------------------------------
+
     @classmethod
     def get_default_settings_schema(cls) -> Dict[str, Any]:
         return {
@@ -162,8 +164,6 @@ class ClientHandler(LanguageHandler, ClientHandlerInterface):
             'languages': [],
             'settings': {},
         }
-
-    # --- Internals ---------------------------------------------------------------------------------------------------
 
     def __init__(self):
         super().__init__()

--- a/st3/lsp_utils/generic_client_handler.py
+++ b/st3/lsp_utils/generic_client_handler.py
@@ -108,7 +108,6 @@ class GenericClientHandler(ClientHandler, metaclass=ABCMeta):
     def read_settings(cls) -> Tuple[sublime.Settings, str]:
         filename = "{}.sublime-settings".format(cls.package_name)
         loaded_settings = sublime.load_settings(filename)
-        cls.on_settings_read_internal(loaded_settings)
         changed = cls.on_settings_read(loaded_settings)
         if changed:
             sublime.save_settings(filename)

--- a/st3/lsp_utils/generic_client_handler.py
+++ b/st3/lsp_utils/generic_client_handler.py
@@ -112,16 +112,6 @@ class GenericClientHandler(ClientHandler, metaclass=ABCMeta):
         changed = cls.on_settings_read(loaded_settings)
         if changed:
             sublime.save_settings(filename)
-        settings = {}
-        for key, default in cls.get_default_settings_schema().items():
-            settings[key] = loaded_settings.get(key, default)
-        # Pass a copy of the settings to the "on_client_configuration_ready" and copy back returned values.
-        settings_copy = {}
-        for key, default in cls.get_default_settings_schema().items():
-            settings_copy[key] = settings.get(key, default)
-        cls.on_client_configuration_ready(settings_copy)
-        for key in cls.get_default_settings_schema().keys():
-            loaded_settings.set(key, settings_copy[key])
         filepath = "Packages/{}/{}".format(cls.package_name, filename)
         return (loaded_settings, filepath)
 
@@ -176,15 +166,6 @@ class GenericClientHandler(ClientHandler, metaclass=ABCMeta):
         :returns: `True` to save modifications back into the settings file.
         """
         return False
-
-    @classmethod
-    def on_client_configuration_ready(cls, configuration: Dict) -> None:
-        """
-        Called with the final client configuration object that contains merged default and user settings.
-
-        Can be used to alter default configuration before registering it.
-        """
-        pass
 
     @classmethod
     def is_allowed_to_start(

--- a/st3/lsp_utils/npm_client_handler.py
+++ b/st3/lsp_utils/npm_client_handler.py
@@ -113,6 +113,7 @@ class NpmClientHandler(GenericClientHandler):
         node_env = cls._node_env()
         if node_env:
             configuration.env.update(node_env)
+        return None
 
     # --- Internal ----------------------------------------------------------------------------------------------------
 

--- a/st3/lsp_utils/npm_client_handler.py
+++ b/st3/lsp_utils/npm_client_handler.py
@@ -1,8 +1,11 @@
 from .generic_client_handler import GenericClientHandler
 from .server_npm_resource import ServerNpmResource
 from .server_resource_interface import ServerResourceInterface
-from LSP.plugin.core.typing import Any, Dict, List, Optional, Tuple
+from LSP.plugin import ClientConfig
+from LSP.plugin import WorkspaceFolder
+from LSP.plugin.core.typing import Dict, List, Optional, Tuple
 from os import path
+import sublime
 
 __all__ = ['NpmClientHandler']
 
@@ -102,10 +105,14 @@ class NpmClientHandler(GenericClientHandler):
         return cls.__server
 
     @classmethod
-    def on_client_configuration_ready(cls, configuration: Dict[str, Any]) -> None:
-        super().on_client_configuration_ready(configuration)
-        if cls._node_env():
-            configuration.setdefault('env', {}).update(cls._node_env())
+    def can_start(cls, window: sublime.Window, initiating_view: sublime.View,
+                  workspace_folders: List[WorkspaceFolder], configuration: ClientConfig) -> Optional[str]:
+        reason = super().can_start(window, initiating_view, workspace_folders, configuration)
+        if reason:
+            return reason
+        node_env = cls._node_env()
+        if node_env:
+            configuration.env.update(node_env)
 
     # --- Internal ----------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Instead of mutating the actual sublime settings, modify the client
configuration from "can_start".

Also removes the `on_client_configuration_ready` API since nothing
seems to be using it and it's not ideal to use it anyway.

Fixes https://github.com/sublimelsp/LSP/pull/1907#issuecomment-981113099
Fixes #84