### PR TITLE
Update bundled Node version to latest LTS version (16)

### DIFF
--- a/st3/lsp_utils/node_runtime.py
+++ b/st3/lsp_utils/node_runtime.py
@@ -22,7 +22,7 @@ __all__ = ['NodeRuntime', 'NodeRuntimePATH', 'NodeRuntimeLocal']
 IS_MAC_ARM = sublime.platform() == 'osx' and sublime.arch() == 'arm64'
 IS_WINDOWS_7_OR_LOWER = sys.platform == 'win32' and sys.getwindowsversion()[:2] <= (6, 1)  # type: ignore
 
-DEFAULT_NODE_VERSION = '16.2.0' if IS_MAC_ARM else '14.17.6'
+DEFAULT_NODE_VERSION = '16.15.0'
 NODE_DIST_URL = 'https://nodejs.org/dist/v{version}/{filename}'
 NO_NODE_FOUND_MESSAGE = 'Could not start {package_name} due to not being able to find Node.js \
 runtime on the PATH. Press the "Install Node.js" button to install Node.js automatically \


### PR DESCRIPTION
Time to finally update to the latest Node LTS version since we'll have a package that requires it (https://github.com/sublimelsp/LSP-Grammarly).

Unfortunately we don't have a way to clean old node installations from Cache. We could add a cleanup routine in the future but deleting stuff is always a bit risky.