### PR TITLE
fix npm install not running when local node_modules exists

### DIFF
--- a/st3/lsp_utils/server_npm_resource.py
+++ b/st3/lsp_utils/server_npm_resource.py
@@ -101,9 +101,7 @@ class ServerNpmResource(ServerResourceInterface):
                 shutil.rmtree(self._server_dest)
             ResourcePath(self._server_src).copytree(self._server_dest, exist_ok=True)
             if not self._skip_npm_install:
-                dependencies_installed = path.isdir(path.join(self._server_dest, 'node_modules'))
-                if not dependencies_installed:
-                    self._node_runtime.npm_install(self._server_dest)
+                self._node_runtime.npm_install(self._server_dest)
             remove(self._installation_marker_file)
         except Exception as error:
             self._status = ServerStatus.ERROR


### PR DESCRIPTION
This fixes an issue that would only potentially affect developers working on LSP-* packages.

If someone did an `npm install` in, for example, a local `LSP-pyright/language-server/` repository then lsp_utils would not run `npm install` even after dependency is bumped in `package.json` which means that ST would use old version of the server.

I'm not sure why this check for `node_modules` already existing was there. Since `install_or_update` only runs when `needs_installation` decided that it needs to be installed, it seems to make sense to do it unconditionally. But I might be forgetting some case that it optimized...

@predragnikolic this is likely the reason you had similar issue before with server not updating.