### PR TITLE
Allow use of electron runtime for Node-based servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Module with LSP-related utilities for Sublime Text
 }
 ```
 
-2. Run the **Package Control: Satisfy Dependencies** command via command palette
-
+2. Run the **Package Control: Satisfy Dependencies** command via the _Command Palette_.
 
 See also [Documentation on Dependencies](https://packagecontrol.io/docs/dependencies)

--- a/lsp_utils.sublime-settings
+++ b/lsp_utils.sublime-settings
@@ -7,7 +7,7 @@
     // with the later one being used as a fallback.
     // You can also specify just a single value to disable the fallback.
     "nodejs_runtime": ["system", "local"],
-    // Uses Node.js runtime from the Electron package rather than the standard one. This has the benefit of lower
+    // Uses Node.js runtime from the Electron package rather than the official distribution. This has the benefit of lower
     // memory usage due it having pointer compression (https://v8.dev/blog/pointer-compression) enabled.
     // Only relevant when using `local` variant of `nodejs_runtime`.
     "local_use_electron": false,

--- a/lsp_utils.sublime-settings
+++ b/lsp_utils.sublime-settings
@@ -11,9 +11,4 @@
     // memory usage due it having pointer compression (https://v8.dev/blog/pointer-compression) enabled.
     // Only relevant when using `local` variant of `nodejs_runtime`.
     "local_use_electron": false,
-    // NPM configuration options used when running NPM with the `local` runtime.
-    // Local runtime doesn't use user configuration in ~/.npmrc so you can use this setting
-    // to pass any custom options instead.
-    // Refer to https://docs.npmjs.com/cli/v9/using-npm/config for the list of options.
-    "local_npm_config": {}
 }

--- a/lsp_utils.sublime-settings
+++ b/lsp_utils.sublime-settings
@@ -7,4 +7,8 @@
     // with the later one being used as a fallback.
     // You can also specify just a single value to disable the fallback.
     "nodejs_runtime": ["system", "local"],
+    // Uses Node.js runtime from the Electron package rather than the standard one. This has the benefit of lower
+    // memory usage due it having pointer compression (https://v8.dev/blog/pointer-compression) enabled.
+    // Only relevant when using `local` variant of `nodejs_runtime`.
+    "use_electron_for_local_runtime": false,
 }

--- a/lsp_utils.sublime-settings
+++ b/lsp_utils.sublime-settings
@@ -10,7 +10,7 @@
     // Uses Node.js runtime from the Electron package rather than the official distribution. This has the benefit of lower
     // memory usage due it having pointer compression (https://v8.dev/blog/pointer-compression) enabled.
     // Only relevant when using `local` variant of `nodejs_runtime`.
-    "local_use_electron": true,
+    "local_use_electron": false,
     // NPM configuration options used when running NPM with the `local` runtime.
     // Local runtime doesn't use user configuration in ~/.npmrc so you can use this setting
     // to pass any custom options instead.

--- a/lsp_utils.sublime-settings
+++ b/lsp_utils.sublime-settings
@@ -10,7 +10,7 @@
     // Uses Node.js runtime from the Electron package rather than the official distribution. This has the benefit of lower
     // memory usage due it having pointer compression (https://v8.dev/blog/pointer-compression) enabled.
     // Only relevant when using `local` variant of `nodejs_runtime`.
-    "local_use_electron": false,
+    "local_use_electron": true,
     // NPM configuration options used when running NPM with the `local` runtime.
     // Local runtime doesn't use user configuration in ~/.npmrc so you can use this setting
     // to pass any custom options instead.

--- a/lsp_utils.sublime-settings
+++ b/lsp_utils.sublime-settings
@@ -10,5 +10,10 @@
     // Uses Node.js runtime from the Electron package rather than the standard one. This has the benefit of lower
     // memory usage due it having pointer compression (https://v8.dev/blog/pointer-compression) enabled.
     // Only relevant when using `local` variant of `nodejs_runtime`.
-    "use_electron_for_local_runtime": false,
+    "local_use_electron": false,
+    // NPM configuration options used when running NPM with the `local` runtime.
+    // Local runtime doesn't use user configuration in ~/.npmrc so you can use this setting
+    // to pass any custom options instead.
+    // Refer to https://docs.npmjs.com/cli/v9/using-npm/config for the list of options.
+    "local_npm_config": {}
 }

--- a/lsp_utils.sublime-settings
+++ b/lsp_utils.sublime-settings
@@ -7,8 +7,8 @@
     // with the later one being used as a fallback.
     // You can also specify just a single value to disable the fallback.
     "nodejs_runtime": ["system", "local"],
-    // Uses Node.js runtime from the Electron package rather than the official distribution. This has the benefit of lower
-    // memory usage due it having pointer compression (https://v8.dev/blog/pointer-compression) enabled.
+    // Uses Node.js runtime from the Electron package rather than the official distribution. This has the benefit of
+    // lower memory usage due to it having the pointer compression (https://v8.dev/blog/pointer-compression) enabled.
     // Only relevant when using `local` variant of `nodejs_runtime`.
     "local_use_electron": false,
 }

--- a/st3/lsp_utils/__init__.py
+++ b/st3/lsp_utils/__init__.py
@@ -2,6 +2,7 @@ from ._client_handler import ClientHandler
 from ._client_handler import notification_handler
 from ._client_handler import request_handler
 from .api_wrapper_interface import ApiWrapperInterface
+from .constants import SETTINGS_FILENAME
 from .generic_client_handler import GenericClientHandler
 from .node_runtime import NodeRuntime
 from .npm_client_handler import NpmClientHandler
@@ -13,6 +14,7 @@ from .server_resource_interface import ServerStatus
 __all__ = [
     'ApiWrapperInterface',
     'ClientHandler',
+    'SETTINGS_FILENAME',
     'GenericClientHandler',
     'NodeRuntime',
     'NpmClientHandler',

--- a/st3/lsp_utils/constants.py
+++ b/st3/lsp_utils/constants.py
@@ -1,0 +1,1 @@
+SETTINGS_FILENAME = 'lsp_utils.sublime-settings'

--- a/st3/lsp_utils/node_runtime.py
+++ b/st3/lsp_utils/node_runtime.py
@@ -222,6 +222,8 @@ class NodeRuntimeLocal(NodeRuntime):
 
     def node_env(self) -> Dict[str, str]:
         extra_env = super().node_env()
+        # Don't use user's local NPM config.
+        extra_env.update({'NPM_CONFIG_USERCONFIG': '/dev/null'})
         if self._use_electron:
             extra_env.update({'ELECTRON_RUN_AS_NODE': 'true'})
         return extra_env

--- a/st3/lsp_utils/node_runtime.py
+++ b/st3/lsp_utils/node_runtime.py
@@ -129,6 +129,9 @@ class NodeRuntime:
         return '{}(node: {}, npm: {}, version: {})'.format(
             self.__class__.__name__, self._node, self._npm, self._version if self._version else None)
 
+    def install_node(self) -> None:
+        raise Exception('Not supported!')
+
     def node_bin(self) -> Optional[str]:
         return self._node
 
@@ -341,24 +344,10 @@ class ElectronRuntimeLocal(NodeRuntime):
         if not path.isfile(self._install_in_progress_marker_file):
             self._resolve_paths()
 
-    def _resolve_paths(self) -> None:
-        self._node = self._resolve_binary()
-        self._npm = path.join(self._base_dir, 'yarn.js')
-
-    def _resolve_binary(self) -> Optional[str]:
-        binary_path = None
-        platform = sublime.platform()
-        if platform == 'osx':
-            binary_path = path.join(self._base_dir, 'Electron.app', 'Contents', 'MacOS', 'Electron')
-        elif platform == 'windows':
-            binary_path = path.join(self._base_dir, 'electron.exe')
-        else:
-            binary_path = path.join(self._base_dir, 'electron')
-        return binary_path if binary_path and path.isfile(binary_path) else None
+    # --- NodeRuntime overrides ----------------------------------------------------------------------------------------
 
     def node_env(self) -> Dict[str, str]:
         extra_env = super().node_env()
-        # Don't use user's local NPM config.
         extra_env.update({'ELECTRON_RUN_AS_NODE': 'true'})
         return extra_env
 
@@ -382,6 +371,23 @@ class ElectronRuntimeLocal(NodeRuntime):
             # '--verbose',
         ]
         self._run_yarn(args, cwd)
+
+    # --- private methods ----------------------------------------------------------------------------------------------
+
+    def _resolve_paths(self) -> None:
+        self._node = self._resolve_binary()
+        self._npm = path.join(self._base_dir, 'yarn.js')
+
+    def _resolve_binary(self) -> Optional[str]:
+        binary_path = None
+        platform = sublime.platform()
+        if platform == 'osx':
+            binary_path = path.join(self._base_dir, 'Electron.app', 'Contents', 'MacOS', 'Electron')
+        elif platform == 'windows':
+            binary_path = path.join(self._base_dir, 'electron.exe')
+        else:
+            binary_path = path.join(self._base_dir, 'electron')
+        return binary_path if binary_path and path.isfile(binary_path) else None
 
     def _run_yarn(self, args: List[str], cwd: str) -> None:
         if not path.isdir(cwd):

--- a/st3/lsp_utils/node_runtime.py
+++ b/st3/lsp_utils/node_runtime.py
@@ -1,3 +1,4 @@
+from .constants import SETTINGS_FILENAME
 from .helpers import run_command_sync
 from .helpers import SemanticVersion
 from .helpers import version_to_string
@@ -59,7 +60,7 @@ class NodeRuntime:
     ) -> 'NodeRuntime':
         resolved_runtime = None  # type: Optional[NodeRuntime]
         default_runtimes = ['system', 'local']
-        settings = sublime.load_settings('lsp_utils.sublime-settings')
+        settings = sublime.load_settings(SETTINGS_FILENAME)
         selected_runtimes = cast(List[str], settings.get('nodejs_runtime') or default_runtimes)
         log_lines = ['--- lsp_utils Node.js resolving start ---']
         for runtime_type in selected_runtimes:
@@ -85,7 +86,7 @@ class NodeRuntime:
                     local_runtime.check_binary_present()
                 except Exception:
                     log_lines.append(' * Not downloaded. Asking to download...')
-                    if not sublime.ok_cancel_dialog(
+                    if selected_runtimes != ['local'] and not sublime.ok_cancel_dialog(
                             NO_NODE_FOUND_MESSAGE.format(package_name=package_name), 'Download Node.js'):
                         log_lines.append(' * Download skipped')
                         continue

--- a/st3/lsp_utils/node_runtime.py
+++ b/st3/lsp_utils/node_runtime.py
@@ -87,10 +87,11 @@ class NodeRuntime:
                 except Exception:
                     log_lines.append(' * Not downloaded. Asking to download...')
                     # If first (or only) runtime is "local" then install without asking.
-                    if selected_runtimes[0] == 'local' and not sublime.ok_cancel_dialog(
-                            NO_NODE_FOUND_MESSAGE.format(package_name=package_name), 'Download Node.js'):
-                        log_lines.append(' * Download skipped')
-                        continue
+                    if selected_runtimes[0] != 'local':
+                        if not sublime.ok_cancel_dialog(
+                                NO_NODE_FOUND_MESSAGE.format(package_name=package_name), 'Download Node.js'):
+                            log_lines.append(' * Download skipped')
+                            continue
                     try:
                         local_runtime.install_node()
                     except Exception as ex:

--- a/st3/lsp_utils/node_runtime.py
+++ b/st3/lsp_utils/node_runtime.py
@@ -212,7 +212,7 @@ class NodeRuntimeLocal(NodeRuntime):
         self._base_dir = path.abspath(path.join(base_dir, node_version))
         self._node_version = node_version
         self._node_dir = path.join(self._base_dir, 'node')
-        self._additional_paths = [path.join(self._node_dir, 'bin')]
+        self._additional_paths = [self._node_dir, path.join(self._node_dir, 'bin')]
         self._install_in_progress_marker_file = path.join(self._base_dir, '.installing')
         self._use_electron = use_electron
         self._resolve_paths()

--- a/st3/lsp_utils/node_runtime.py
+++ b/st3/lsp_utils/node_runtime.py
@@ -86,7 +86,8 @@ class NodeRuntime:
                     local_runtime.check_binary_present()
                 except Exception:
                     log_lines.append(' * Not downloaded. Asking to download...')
-                    if selected_runtimes != ['local'] and not sublime.ok_cancel_dialog(
+                    # If first (or only) runtime is "local" then install without asking.
+                    if selected_runtimes[0] == 'local' and not sublime.ok_cancel_dialog(
                             NO_NODE_FOUND_MESSAGE.format(package_name=package_name), 'Download Node.js'):
                         log_lines.append(' * Download skipped')
                         continue

--- a/st3/lsp_utils/node_runtime.py
+++ b/st3/lsp_utils/node_runtime.py
@@ -18,7 +18,7 @@ import tarfile
 import urllib.request
 import zipfile
 
-__all__ = ['NodeRuntime', 'NodeRuntimePATH', 'NodeRuntimeLocal', 'ElectronRuntimeLocal']
+__all__ = ['NodeRuntime']
 
 IS_WINDOWS_7_OR_LOWER = sys.platform == 'win32' and sys.getwindowsversion()[:2] <= (6, 1)  # type: ignore
 
@@ -86,11 +86,8 @@ class NodeRuntime:
             elif runtime_type == 'local':
                 log_lines.append('Resolving Node.js Runtime from lsp_utils for package {}...'.format(package_name))
                 use_electron = cast(bool, settings.get('local_use_electron') or False)
-                node_runtime_directory = path.join(storage_path, 'lsp_utils', 'node-runtime')
-                if use_electron:
-                    local_runtime = ElectronRuntimeLocal(node_runtime_directory)
-                else:
-                    local_runtime = NodeRuntimeLocal(node_runtime_directory)
+                runtime_dir = path.join(storage_path, 'lsp_utils', 'node-runtime')
+                local_runtime = ElectronRuntimeLocal(runtime_dir) if use_electron else NodeRuntimeLocal(runtime_dir)
                 try:
                     local_runtime.check_binary_present()
                 except Exception as ex:

--- a/st3/lsp_utils/node_runtime.py
+++ b/st3/lsp_utils/node_runtime.py
@@ -22,7 +22,7 @@ __all__ = ['NodeRuntime', 'NodeRuntimePATH', 'NodeRuntimeLocal']
 IS_WINDOWS_7_OR_LOWER = sys.platform == 'win32' and sys.getwindowsversion()[:2] <= (6, 1)  # type: ignore
 
 DEFAULT_NODE_VERSION = '16.17.1'
-ELECTRON_VERSION = '22.2.0'
+ELECTRON_VERSION = '22.2.0'  # includes matching 16.17.1 version of Node.js
 NODE_DIST_URL = 'https://nodejs.org/dist/v{version}/{filename}'
 NO_NODE_FOUND_MESSAGE = 'Could not start {package_name} due to not being able to resolve suitable Node.js \
 runtime on the PATH. Press the "Download Node.js" button to get required Node.js version \

--- a/st3/lsp_utils/node_runtime.py
+++ b/st3/lsp_utils/node_runtime.py
@@ -169,7 +169,7 @@ class NodeRuntime:
     ) -> Optional[subprocess.Popen]:
         node_bin = self.node_bin()
         if node_bin is None:
-            return
+            return None
         os_env = os.environ.copy()
         os_env.update(self.node_env())
         os_env.update(env)
@@ -276,7 +276,7 @@ class NodeRuntimeLocal(NodeRuntime):
 
     def _resolve_electron_binary(self) -> Optional[str]:
         if not self._use_electron:
-            return
+            return None
         electron_dist_dir = path.join(self._resolve_lib(), 'electron', 'dist')
         binary_path = None
         platform = sublime.platform()

--- a/st3/lsp_utils/node_runtime.py
+++ b/st3/lsp_utils/node_runtime.py
@@ -159,8 +159,14 @@ class NodeRuntime:
             raise Exception('Error resolving Node.js version:\n{}'.format(error))
         return self._version
 
-    def run_node(self, args: List[str], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                 env: Dict[str, Any] = {}) -> Optional[subprocess.Popen]:
+    def run_node(
+        self,
+        args: List[str],
+        stdin: int = subprocess.PIPE,
+        stdout: int = subprocess.PIPE,
+        stderr: int = subprocess.PIPE,
+        env: Dict[str, Any] = {}
+    ) -> Optional[subprocess.Popen]:
         node_bin = self.node_bin()
         if node_bin is None:
             return

--- a/st3/lsp_utils/node_runtime.py
+++ b/st3/lsp_utils/node_runtime.py
@@ -14,16 +14,22 @@ import shutil
 import sublime
 import subprocess
 import sys
+import tarfile
 import urllib.request
+import zipfile
 
-__all__ = ['NodeRuntime', 'NodeRuntimePATH', 'NodeRuntimeLocal']
+__all__ = ['NodeRuntime', 'NodeRuntimePATH', 'NodeRuntimeLocal', 'ElectronRuntimeLocal']
 
 IS_WINDOWS_7_OR_LOWER = sys.platform == 'win32' and sys.getwindowsversion()[:2] <= (6, 1)  # type: ignore
 
-DEFAULT_NODE_VERSION = '16.17.1'
-ELECTRON_VERSION = '22.2.0'  # includes matching 16.17.1 version of Node.js
+NODE_RUNTIME_VERSION = '16.15.0'
+NODE_DIST_URL = 'https://nodejs.org/dist/v{version}/{filename}'
+
+ELECTRON_RUNTIME_VERSION = '22.2.0'  # includes Node.js v16.17.1
+ELECTRON_NODE_VERSION = '16.17.1'
 ELECTRON_DIST_URL = 'https://github.com/electron/electron/releases/download/v{version}/{filename}'
 YARN_URL = 'https://github.com/yarnpkg/yarn/releases/download/v1.22.19/yarn-1.22.19.js'
+
 NO_NODE_FOUND_MESSAGE = 'Could not start {package_name} due to not being able to resolve suitable Node.js \
 runtime on the PATH. Press the "Download Node.js" button to get required Node.js version \
 (note that it will be used only by LSP and will not affect your system otherwise).'
@@ -80,14 +86,15 @@ class NodeRuntime:
             elif runtime_type == 'local':
                 log_lines.append('Resolving Node.js Runtime from lsp_utils for package {}...'.format(package_name))
                 use_electron = cast(bool, settings.get('local_use_electron') or False)
-                npm_config = cast(dict, settings.get('local_npm_config') or {})
-                local_runtime = NodeRuntimeLocal(
-                    path.join(storage_path, 'lsp_utils', 'node-runtime'), use_electron, npm_config)
+                node_runtime_directory = path.join(storage_path, 'lsp_utils', 'node-runtime')
+                if use_electron:
+                    local_runtime = ElectronRuntimeLocal(node_runtime_directory)
+                else:
+                    local_runtime = NodeRuntimeLocal(node_runtime_directory)
                 try:
                     local_runtime.check_binary_present()
                 except Exception as ex:
                     log_lines.append(' * Binaries check failed: {}'.format(ex))
-                    # If first (or only) runtime is "local" then install without asking.
                     if selected_runtimes[0] != 'local':
                         if not sublime.ok_cancel_dialog(
                                 NO_NODE_FOUND_MESSAGE.format(package_name=package_name), 'Download Node.js'):
@@ -181,20 +188,26 @@ class NodeRuntime:
         return subprocess.Popen(
             [node_bin] + args, stdin=stdin, stdout=stdout, stderr=stderr, env=os_env, startupinfo=startupinfo)
 
-    def run_npm(self, args: List[str], cwd: str) -> None:
+    def run_install(self, cwd: str) -> None:
         if not path.isdir(cwd):
             raise Exception('Specified working directory "{}" does not exist'.format(cwd))
         if not self._node:
-            raise Exception('Node.js not installed. Use ElectronInstaller to install it first.')
+            raise Exception('Node.js not installed. Use NodeInstaller to install it first.')
+        args = [
+            'ci',
+            '--scripts-prepend-node-path=true',
+            '--verbose',
+            '--omit=dev',
+        ]
         stdout, error = run_command_sync(
-            self._npm_command() + args, cwd=cwd, extra_env=self.node_env(), extra_paths=self._additional_paths)
+            self.npm_command() + args, cwd=cwd, extra_env=self.node_env(), extra_paths=self._additional_paths)
         print('[lsp_utils] START output of command: "{}"'.format(' '.join(args)))
         print(stdout)
         print('[lsp_utils] Command output END')
         if error is not None:
             raise Exception('Failed to run npm command "{}":\n{}'.format(' '.join(args), error))
 
-    def _npm_command(self) -> List[str]:
+    def npm_command(self) -> List[str]:
         if self._npm is None:
             raise Exception('Npm command not initialized')
         return [self._npm]
@@ -208,34 +221,20 @@ class NodeRuntimePATH(NodeRuntime):
 
 
 class NodeRuntimeLocal(NodeRuntime):
-    def __init__(
-        self, base_dir: str, use_electron: bool, npm_config: Dict[str, str], node_version: str = DEFAULT_NODE_VERSION
-    ):
+    def __init__(self, base_dir: str, node_version: str = NODE_RUNTIME_VERSION):
         super().__init__()
         self._base_dir = path.abspath(path.join(base_dir, node_version))
         self._node_version = node_version
         self._node_dir = path.join(self._base_dir, 'node')
-        self._additional_paths = [self._node_dir, path.join(self._node_dir, 'bin')]
+        self._additional_paths = [path.join(self._node_dir, 'bin')]
         self._install_in_progress_marker_file = path.join(self._base_dir, '.installing')
-        self._use_electron = use_electron
-        self._npm_flags = []
-        for key, value in npm_config.items():
-            self._npm_flags.append('--{}={}'.format(key, value))
-        self._npm_config = npm_config
-        if not path.isfile(self._install_in_progress_marker_file):
-            self._resolve_paths()
-
-    def node_env(self) -> Dict[str, str]:
-        extra_env = super().node_env()
-        # Don't use user's local NPM config.
-        extra_env.update({'NPM_CONFIG_USERCONFIG': '/dev/null'})
-        if self._use_electron:
-            extra_env.update({'ELECTRON_RUN_AS_NODE': 'true'})
-        return extra_env
+        self._resolve_paths()
 
     def _resolve_paths(self) -> None:
-        self._node = self._resolve_electron_binary()
-        self._npm = path.join(self._base_dir, 'yarn.js')
+        if path.isfile(self._install_in_progress_marker_file):
+            # Will trigger re-installation.
+            return
+        self._node = self._resolve_binary()
 
     def _resolve_binary(self) -> Optional[str]:
         exe_path = path.join(self._node_dir, 'node.exe')
@@ -246,49 +245,32 @@ class NodeRuntimeLocal(NodeRuntime):
             return binary_path
         return None
 
-    def _npm_command(self) -> List[str]:
+    def resolve_lib(self) -> str:
+        lib_path = path.join(self._node_dir, 'lib', 'node_modules')
+        if not path.isdir(lib_path):
+            lib_path = path.join(self._node_dir, 'node_modules')
+        return lib_path
+
+    def npm_command(self) -> List[str]:
         if not self._node or not self._npm:
             raise Exception('Node.js or Npm command not initialized')
-        return [self._node, self._npm] + self._npm_flags
+        return [self._node, self._npm]
 
     def install_node(self) -> None:
         os.makedirs(os.path.dirname(self._install_in_progress_marker_file), exist_ok=True)
         open(self._install_in_progress_marker_file, 'a').close()
         with ActivityIndicator(sublime.active_window(), 'Downloading Node.js'):
-            install_node = ElectronInstaller(self._base_dir, self._node_version)
+            install_node = NodeInstaller(self._base_dir, self._node_version)
             install_node.run()
             self._resolve_paths()
-            # ZipFile removes permissions, make server executable
-            if self._node and sublime.platform() != 'windows':
-                os.chmod(self._node, 0o755)
-            # if self._use_electron:
-            #     self.run_npm(['install', '-g', 'electron@{}'.format(ELECTRON_VERSION)], cwd=self._node_dir)
-            #     self._node = self._resolve_electron_binary()
         remove(self._install_in_progress_marker_file)
-
-    def check_satisfies_version(self, required_node_version: NpmSpec) -> None:
-        super().check_satisfies_version(required_node_version)
-        if self._use_electron:
-            self._node = self._resolve_electron_binary()
-
-    def _resolve_electron_binary(self) -> Optional[str]:
-        if not self._use_electron:
-            return None
-        binary_path = None
-        platform = sublime.platform()
-        if platform == 'osx':
-            binary_path = path.join(self._base_dir, 'Electron.app', 'Contents', 'MacOS', 'Electron')
-        elif platform == 'windows':
-            binary_path = path.join(self._base_dir, 'electron.exe')
-        else:
-            binary_path = path.join(self._base_dir, 'electron')
-        return binary_path if binary_path and path.isfile(binary_path) else None
+        self._resolve_paths()
 
 
-class ElectronInstaller:
+class NodeInstaller:
     '''Command to install a local copy of Node.js'''
 
-    def __init__(self, base_dir: str, node_version: str = DEFAULT_NODE_VERSION) -> None:
+    def __init__(self, base_dir: str, node_version: str = NODE_RUNTIME_VERSION) -> None:
         """
         :param base_dir: The base directory for storing given Node.js runtime version
         :param node_version: The Node.js version to install
@@ -300,8 +282,138 @@ class ElectronInstaller:
     def run(self) -> None:
         archive, url = self._node_archive()
         print('[lsp_utils] Downloading Node.js {} from {}'.format(self._node_version, url))
-        if not self._node_archive_exists(archive):
+        if not self._archive_exists(archive):
             self._download_node(url, archive)
+        self._install_node(archive)
+
+    def _node_archive(self) -> Tuple[str, str]:
+        platform = sublime.platform()
+        arch = sublime.arch()
+        if platform == 'windows' and arch == 'x64':
+            node_os = 'win'
+            archive = 'zip'
+        elif platform == 'linux':
+            node_os = 'linux'
+            archive = 'tar.gz'
+        elif platform == 'osx':
+            node_os = 'darwin'
+            archive = 'tar.gz'
+        else:
+            raise Exception('{} {} is not supported'.format(arch, platform))
+        filename = 'node-v{}-{}-{}.{}'.format(self._node_version, node_os, arch, archive)
+        dist_url = NODE_DIST_URL.format(version=self._node_version, filename=filename)
+        return filename, dist_url
+
+    def _archive_exists(self, filename: str) -> bool:
+        archive = path.join(self._cache_dir, filename)
+        return path.isfile(archive)
+
+    def _download_node(self, url: str, filename: str) -> None:
+        if not path.isdir(self._cache_dir):
+            os.makedirs(self._cache_dir)
+        archive = path.join(self._cache_dir, filename)
+        with urllib.request.urlopen(url) as response:
+            with open(archive, 'wb') as f:
+                shutil.copyfileobj(response, f)
+
+    def _install_node(self, filename: str) -> None:
+        archive = path.join(self._cache_dir, filename)
+        opener = zipfile.ZipFile if filename.endswith('.zip') else tarfile.open  # type: Any
+        try:
+            with opener(archive) as f:
+                names = f.namelist() if hasattr(f, 'namelist') else f.getnames()
+                install_dir, _ = next(x for x in names if '/' in x).split('/', 1)
+                bad_members = [x for x in names if x.startswith('/') or x.startswith('..')]
+                if bad_members:
+                    raise Exception('{} appears to be malicious, bad filenames: {}'.format(filename, bad_members))
+                f.extractall(self._base_dir)
+                with chdir(self._base_dir):
+                    os.rename(install_dir, 'node')
+        except Exception as ex:
+            raise ex
+        finally:
+            remove(archive)
+
+
+class ElectronRuntimeLocal(NodeRuntime):
+    def __init__(self, base_dir: str):
+        super().__init__()
+        self._base_dir = path.abspath(path.join(base_dir, ELECTRON_NODE_VERSION))
+        self._yarn = path.join(self._base_dir, 'yarn.js')
+        self._install_in_progress_marker_file = path.join(self._base_dir, '.installing')
+        if not path.isfile(self._install_in_progress_marker_file):
+            self._resolve_paths()
+
+    def _resolve_paths(self) -> None:
+        self._node = self._resolve_binary()
+        self._npm = path.join(self._base_dir, 'yarn.js')
+
+    def _resolve_binary(self) -> Optional[str]:
+        binary_path = None
+        platform = sublime.platform()
+        if platform == 'osx':
+            binary_path = path.join(self._base_dir, 'Electron.app', 'Contents', 'MacOS', 'Electron')
+        elif platform == 'windows':
+            binary_path = path.join(self._base_dir, 'electron.exe')
+        else:
+            binary_path = path.join(self._base_dir, 'electron')
+        return binary_path if binary_path and path.isfile(binary_path) else None
+
+    def node_env(self) -> Dict[str, str]:
+        extra_env = super().node_env()
+        # Don't use user's local NPM config.
+        extra_env.update({'ELECTRON_RUN_AS_NODE': 'true'})
+        return extra_env
+
+    def install_node(self) -> None:
+        os.makedirs(os.path.dirname(self._install_in_progress_marker_file), exist_ok=True)
+        open(self._install_in_progress_marker_file, 'a').close()
+        with ActivityIndicator(sublime.active_window(), 'Downloading Node.js'):
+            install_node = ElectronInstaller(self._base_dir)
+            install_node.run()
+            self._resolve_paths()
+        remove(self._install_in_progress_marker_file)
+
+    def run_install(self, cwd: str) -> None:
+        self._run_yarn(['import'], cwd)
+        args = [
+            'install',
+            '--production',
+            '--frozen-lockfile',
+            '--scripts-prepend-node-path=true',
+            '--cache-folder={}'.format(path.join(self._base_dir, 'cache', 'yarn')),
+            # '--verbose',
+        ]
+        self._run_yarn(args, cwd)
+
+    def _run_yarn(self, args: List[str], cwd: str) -> None:
+        if not path.isdir(cwd):
+            raise Exception('Specified working directory "{}" does not exist'.format(cwd))
+        if not self._node:
+            raise Exception('Node.js not installed. Use NodeInstaller to install it first.')
+        stdout, error = run_command_sync([self._node, self._yarn] + args, cwd=cwd, extra_env=self.node_env())
+        print('[lsp_utils] START output of command: "{}"'.format(' '.join(args)))
+        print(stdout)
+        print('[lsp_utils] Command output END')
+        if error is not None:
+            raise Exception('Failed to run yarn command "{}":\n{}'.format(' '.join(args), error))
+
+
+class ElectronInstaller:
+    '''Command to install a local copy of Node.js'''
+
+    def __init__(self, base_dir: str) -> None:
+        """
+        :param base_dir: The base directory for storing given Node.js runtime version
+        """
+        self._base_dir = base_dir
+        self._cache_dir = path.join(self._base_dir, 'cache')
+
+    def run(self) -> None:
+        archive, url = self._node_archive()
+        print('[lsp_utils] Downloading Electron {} from {}'.format(ELECTRON_NODE_VERSION, url))
+        if not self._archive_exists(archive):
+            self._download(url, archive)
         self._install(archive)
         self._download_yarn()
 
@@ -316,15 +428,15 @@ class ElectronInstaller:
             platform_code = 'darwin'
         else:
             raise Exception('{} {} is not supported'.format(arch, platform))
-        filename = 'electron-v{}-{}-{}.zip'.format(ELECTRON_VERSION, platform_code, arch)
-        dist_url = ELECTRON_DIST_URL.format(version=ELECTRON_VERSION, filename=filename)
+        filename = 'electron-v{}-{}-{}.zip'.format(ELECTRON_RUNTIME_VERSION, platform_code, arch)
+        dist_url = ELECTRON_DIST_URL.format(version=ELECTRON_RUNTIME_VERSION, filename=filename)
         return filename, dist_url
 
-    def _node_archive_exists(self, filename: str) -> bool:
+    def _archive_exists(self, filename: str) -> bool:
         archive = path.join(self._cache_dir, filename)
         return path.isfile(archive)
 
-    def _download_node(self, url: str, filename: str) -> None:
+    def _download(self, url: str, filename: str) -> None:
         if not path.isdir(self._cache_dir):
             os.makedirs(self._cache_dir)
         archive = path.join(self._cache_dir, filename)
@@ -335,13 +447,19 @@ class ElectronInstaller:
     def _install(self, filename: str) -> None:
         archive = path.join(self._cache_dir, filename)
         try:
-            with ZipFileWithFixedPermissions(archive) as f:
-                names = f.namelist()
-                _, _ = next(x for x in names if '/' in x).split('/', 1)
-                bad_members = [x for x in names if x.startswith('/') or x.startswith('..')]
-                if bad_members:
-                    raise Exception('{} appears to be malicious, bad filenames: {}'.format(filename, bad_members))
-                f.extractall(self._base_dir)
+            if sublime.platform() == 'windows':
+                with zipfile.ZipFile(archive) as f:
+                    names = f.namelist()
+                    _, _ = next(x for x in names if '/' in x).split('/', 1)
+                    bad_members = [x for x in names if x.startswith('/') or x.startswith('..')]
+                    if bad_members:
+                        raise Exception('{} appears to be malicious, bad filenames: {}'.format(filename, bad_members))
+                    f.extractall(self._base_dir)
+            else:
+                # ZipFile doesn't handle symlinks and permissions correctly on Linux and Mac. Use unzip instead.
+                _, error = run_command_sync(['unzip', archive, '-d', self._base_dir], cwd=self._cache_dir)
+                if error:
+                    raise Exception('Error unzipping electron archive: {}'.format(error))
         except Exception as ex:
             raise ex
         finally:

--- a/st3/lsp_utils/npm_client_handler.py
+++ b/st3/lsp_utils/npm_client_handler.py
@@ -132,6 +132,11 @@ class NpmClientHandler(GenericClientHandler):
         return cls.__server
 
     @classmethod
+    def cleanup(cls) -> None:
+        cls.__server = None
+        super().cleanup()
+
+    @classmethod
     def can_start(cls, window: sublime.Window, initiating_view: sublime.View,
                   workspace_folders: List[WorkspaceFolder], configuration: ClientConfig) -> Optional[str]:
         reason = super().can_start(window, initiating_view, workspace_folders, configuration)

--- a/st3/lsp_utils/server_npm_resource.py
+++ b/st3/lsp_utils/server_npm_resource.py
@@ -104,7 +104,13 @@ class ServerNpmResource(ServerResourceInterface):
                 shutil.rmtree(self._server_dest)
             ResourcePath(self._server_src).copytree(self._server_dest, exist_ok=True)
             if not self._skip_npm_install:
-                self._node_runtime.npm_install(self._server_dest)
+                args = [
+                    'ci',
+                    '--scripts-prepend-node-path=true',
+                    '--verbose',
+                    '--omit dev',
+                ]
+                self._node_runtime.run_npm(args, cwd=self._server_dest)
             remove(self._installation_marker_file)
         except Exception as error:
             self._status = ServerStatus.ERROR

--- a/st3/lsp_utils/server_npm_resource.py
+++ b/st3/lsp_utils/server_npm_resource.py
@@ -104,11 +104,12 @@ class ServerNpmResource(ServerResourceInterface):
                 shutil.rmtree(self._server_dest)
             ResourcePath(self._server_src).copytree(self._server_dest, exist_ok=True)
             if not self._skip_npm_install:
+                self._node_runtime.run_npm(['import'], cwd=self._server_dest)
                 args = [
-                    'ci',
+                    '--frozen-lockfile',
                     '--scripts-prepend-node-path=true',
-                    '--verbose',
-                    '--omit=dev',
+                    # '--verbose',
+                    '--production',
                 ]
                 self._node_runtime.run_npm(args, cwd=self._server_dest)
             remove(self._installation_marker_file)

--- a/st3/lsp_utils/server_npm_resource.py
+++ b/st3/lsp_utils/server_npm_resource.py
@@ -104,14 +104,7 @@ class ServerNpmResource(ServerResourceInterface):
                 shutil.rmtree(self._server_dest)
             ResourcePath(self._server_src).copytree(self._server_dest, exist_ok=True)
             if not self._skip_npm_install:
-                self._node_runtime.run_npm(['import'], cwd=self._server_dest)
-                args = [
-                    '--frozen-lockfile',
-                    '--scripts-prepend-node-path=true',
-                    # '--verbose',
-                    '--production',
-                ]
-                self._node_runtime.run_npm(args, cwd=self._server_dest)
+                self._node_runtime.run_install(cwd=self._server_dest)
             remove(self._installation_marker_file)
         except Exception as error:
             self._status = ServerStatus.ERROR

--- a/st3/lsp_utils/server_npm_resource.py
+++ b/st3/lsp_utils/server_npm_resource.py
@@ -108,7 +108,7 @@ class ServerNpmResource(ServerResourceInterface):
                     'ci',
                     '--scripts-prepend-node-path=true',
                     '--verbose',
-                    '--omit dev',
+                    '--omit=dev',
                 ]
                 self._node_runtime.run_npm(args, cwd=self._server_dest)
             remove(self._installation_marker_file)

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -28,7 +28,15 @@
               },
               "uniqueItems": true,
             },
-            "use_electron_for_local_runtime": {
+            "local_npm_config": {
+              "type": "object",
+              "items": {
+                "type": "string"
+              },
+              "default": {},
+              "markdownDescription": "NPM configuration options used when running NPM with the `local` runtime.\nLocal runtime doesn't use user configuration in ~/.npmrc so you can use this setting to pass any custom options instead.\n\nRefer to https://docs.npmjs.com/cli/v9/using-npm/config for the list of options."
+            },
+            "local_use_electron": {
               "type": "boolean",
               "default": false,
               "markdownDescription": "Uses Node.js runtime from the Electron package rather than the standard one. This has the benefit of lower memory usage due it having [pointer compression](https://v8.dev/blog/pointer-compression) enabled.\n\nOnly relevant when using `local` variant of `nodejs_runtime`."

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -31,7 +31,7 @@
             "local_use_electron": {
               "type": "boolean",
               "default": false,
-              "markdownDescription": "Uses Node.js runtime from the Electron package rather than the official distribution. This has the benefit of lower memory usage due it having [pointer compression](https://v8.dev/blog/pointer-compression) enabled.\n\nOnly relevant when using `local` variant of `nodejs_runtime`."
+              "markdownDescription": "Uses Node.js runtime from the Electron package rather than the official distribution. This has the benefit of lower memory usage due to it having the [pointer compression](https://v8.dev/blog/pointer-compression) enabled.\n\nOnly relevant when using `local` variant of `nodejs_runtime`."
             }
           },
           "additionalProperties": false,

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -39,7 +39,7 @@
             "local_use_electron": {
               "type": "boolean",
               "default": false,
-              "markdownDescription": "Uses Node.js runtime from the Electron package rather than the standard one. This has the benefit of lower memory usage due it having [pointer compression](https://v8.dev/blog/pointer-compression) enabled.\n\nOnly relevant when using `local` variant of `nodejs_runtime`."
+              "markdownDescription": "Uses Node.js runtime from the Electron package rather than the official distribution. This has the benefit of lower memory usage due it having [pointer compression](https://v8.dev/blog/pointer-compression) enabled.\n\nOnly relevant when using `local` variant of `nodejs_runtime`."
             }
           },
           "additionalProperties": false,

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -38,7 +38,7 @@
             },
             "local_use_electron": {
               "type": "boolean",
-              "default": true,
+              "default": false,
               "markdownDescription": "Uses Node.js runtime from the Electron package rather than the official distribution. This has the benefit of lower memory usage due it having [pointer compression](https://v8.dev/blog/pointer-compression) enabled.\n\nOnly relevant when using `local` variant of `nodejs_runtime`."
             }
           },

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -38,7 +38,7 @@
             },
             "local_use_electron": {
               "type": "boolean",
-              "default": false,
+              "default": true,
               "markdownDescription": "Uses Node.js runtime from the Electron package rather than the official distribution. This has the benefit of lower memory usage due it having [pointer compression](https://v8.dev/blog/pointer-compression) enabled.\n\nOnly relevant when using `local` variant of `nodejs_runtime`."
             }
           },

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -28,14 +28,6 @@
               },
               "uniqueItems": true,
             },
-            "local_npm_config": {
-              "type": "object",
-              "items": {
-                "type": "string"
-              },
-              "default": {},
-              "markdownDescription": "NPM configuration options used when running NPM with the `local` runtime.\nLocal runtime doesn't use user configuration in ~/.npmrc so you can use this setting to pass any custom options instead.\n\nRefer to https://docs.npmjs.com/cli/v9/using-npm/config for the list of options."
-            },
             "local_use_electron": {
               "type": "boolean",
               "default": false,

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -27,6 +27,11 @@
                 ]
               },
               "uniqueItems": true,
+            },
+            "use_electron_for_local_runtime": {
+              "type": "boolean",
+              "default": false,
+              "markdownDescription": "Uses Node.js runtime from the Electron package rather than the standard one. This has the benefit of lower memory usage due it having [pointer compression](https://v8.dev/blog/pointer-compression) enabled.\n\nOnly relevant when using `local` variant of `nodejs_runtime`."
             }
           },
           "additionalProperties": false,

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -52,7 +52,7 @@ class TextDocumentTestCase(DeferrableTestCase):
         yield {'condition': lambda: not cls.view.is_loading(), 'timeout': TIMEOUT_TIME}
         yield cls.ensure_document_listener_created
         # First start needs time to install the dependencies.
-        INSTALL_TIMEOUT = 6000
+        INSTALL_TIMEOUT = 30000
         yield {
             'condition': lambda: cls.wm.get_session(cls.get_session_name(), filename) is not None,
             'timeout': INSTALL_TIMEOUT

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -1,4 +1,3 @@
-from json import dumps
 from LSP.plugin.core.registry import windows
 from LSP.plugin.core.sessions import Session
 from LSP.plugin.core.types import ClientStates

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -1,5 +1,4 @@
 from LSP.plugin.core.registry import windows
-from LSP.plugin.core.sessions import get_plugin
 from LSP.plugin.core.sessions import Session
 from LSP.plugin.core.types import ClientStates
 from LSP.plugin.core.typing import Any, Dict, Generator, Optional
@@ -13,6 +12,8 @@ import sublime
 
 try:
     from LSP.plugin.documents import DocumentSyncListener
+    from LSP.plugin.core.sessions import get_plugin
+    lsp_pyright_class = get_plugin('LSP-pyright')
     ST3 = False
 except ImportError:
     from LSP.plugin.core.documents import DocumentSyncListener
@@ -20,7 +21,6 @@ except ImportError:
 
 TIMEOUT_TIME = 2000
 
-lsp_pyright_class = get_plugin('LSP-pyright')
 
 
 def close_test_view(view: Optional[sublime.View]) -> 'Generator':
@@ -49,7 +49,8 @@ class TextDocumentTestCase(DeferrableTestCase):
     @classmethod
     def setUpClass(cls) -> Generator:
         super().setUpClass()
-        lsp_pyright_class.setup()
+        if not ST3:
+            lsp_pyright_class.setup()
         window = sublime.active_window()
         filename = expand(join('$packages', 'lsp_utils', 'tests', cls.get_test_file_name()), window)
         open_view = window.find_open_file(filename)
@@ -140,7 +141,8 @@ class TextDocumentTestCase(DeferrableTestCase):
         cls.session = None
         cls.wm = None
         cls.remove_lsp_utils_settings()
-        lsp_pyright_class.cleanup()
+        if not ST3:
+            lsp_pyright_class.cleanup()
         super().tearDownClass()
 
     def doCleanups(self) -> 'Generator':

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -22,7 +22,6 @@ except ImportError:
 TIMEOUT_TIME = 2000
 
 
-
 def close_test_view(view: Optional[sublime.View]) -> 'Generator':
     if view:
         view.set_scratch(True)

--- a/tests/test_smoketest.py
+++ b/tests/test_smoketest.py
@@ -1,4 +1,3 @@
-from lsp_utils import NodeRuntime
 from LSP.plugin.core.typing import cast, Generator
 from .setup import TextDocumentTestCase, TIMEOUT_TIME
 

--- a/tests/test_smoketest.py
+++ b/tests/test_smoketest.py
@@ -41,7 +41,7 @@ class LocalRuntime(BaseTestCase):
     def setUpClass(cls) -> Generator:
         cls.set_lsp_utils_settings({
             'nodejs_runtime': ['local'],
-            'use_electron_for_local_runtime': False
+            'local_use_electron': False
         })
         yield from super().setUpClass()
 
@@ -52,6 +52,6 @@ class LocalRuntimeAndElectron(BaseTestCase):
     def setUpClass(cls) -> Generator:
         cls.set_lsp_utils_settings({
             'nodejs_runtime': ['local'],
-            'use_electron_for_local_runtime': True
+            'local_use_electron': True
         })
         yield from super().setUpClass()

--- a/tests/test_smoketest.py
+++ b/tests/test_smoketest.py
@@ -1,3 +1,4 @@
+from lsp_utils import NodeRuntime
 from LSP.plugin.core.typing import cast, Generator
 from .setup import TextDocumentTestCase, TIMEOUT_TIME
 
@@ -8,9 +9,9 @@ except ImportError:
     ST3 = True
 
 
-class PyrightSmokeTests(TextDocumentTestCase):
+class BaseTestCase(TextDocumentTestCase):
 
-    def test_set_and_get(self) -> Generator:
+    def test_diagnostics(self) -> Generator:
         if ST3:
             error_region_key = 'lsp_error'
         else:
@@ -23,3 +24,34 @@ class PyrightSmokeTests(TextDocumentTestCase):
         region = error_regions[0]
         self.assertEqual((region.a, region.b), (6, 7))
         self.view.window().run_command('show_panel', {"panel": "console", "toggle": True})
+
+
+class SystemRuntime(BaseTestCase):
+
+    @classmethod
+    def setUpClass(cls) -> Generator:
+        cls.set_lsp_utils_settings({
+            'nodejs_runtime': ['system'],
+        })
+        yield from super().setUpClass()
+
+
+class LocalRuntime(BaseTestCase):
+
+    @classmethod
+    def setUpClass(cls) -> Generator:
+        cls.set_lsp_utils_settings({
+            'nodejs_runtime': ['local'],
+        })
+        yield from super().setUpClass()
+
+
+class LocalRuntimeAndElectron(BaseTestCase):
+
+    @classmethod
+    def setUpClass(cls) -> Generator:
+        cls.set_lsp_utils_settings({
+            'nodejs_runtime': ['local'],
+            'use_electron_for_local_runtime': True
+        })
+        yield from super().setUpClass()

--- a/tests/test_smoketest.py
+++ b/tests/test_smoketest.py
@@ -35,7 +35,7 @@ class SystemRuntime(BaseTestCase):
         yield from super().setUpClass()
 
 
-class LocalRuntime(BaseTestCase):
+class LocalNodeRuntime(BaseTestCase):
 
     @classmethod
     def setUpClass(cls) -> Generator:
@@ -46,7 +46,7 @@ class LocalRuntime(BaseTestCase):
         yield from super().setUpClass()
 
 
-class LocalRuntimeAndElectron(BaseTestCase):
+class LocalElectronRuntime(BaseTestCase):
 
     @classmethod
     def setUpClass(cls) -> Generator:

--- a/tests/test_smoketest.py
+++ b/tests/test_smoketest.py
@@ -16,7 +16,7 @@ class PyrightSmokeTests(TextDocumentTestCase):
         else:
             session_view = cast(SessionView, self.session.session_view_for_view_async(self.view))
             self.assertIsNotNone(session_view)
-            error_region_key = session_view.diagnostics_key(1, False)
+            error_region_key = '{}_icon'.format(session_view.diagnostics_key(1, multiline=False))
             yield {'condition': lambda: len(session_view.session_buffer.diagnostics) == 1, 'timeout': TIMEOUT_TIME * 4}
         error_regions = yield lambda: self.view.get_regions(error_region_key)
         self.assertEqual(len(error_regions), 1)

--- a/tests/test_smoketest.py
+++ b/tests/test_smoketest.py
@@ -41,6 +41,7 @@ class LocalRuntime(BaseTestCase):
     def setUpClass(cls) -> Generator:
         cls.set_lsp_utils_settings({
             'nodejs_runtime': ['local'],
+            'use_electron_for_local_runtime': False
         })
         yield from super().setUpClass()
 


### PR DESCRIPTION
Since electron builds have [pointer compression](https://v8.dev/blog/pointer-compression) enabled, those use quite a bit less memory than the official Node.js builds.

I haven't been able to find official Node.js builds with pointer compression enabled so using Electron itself is the next best thing and is easiest to handle since those can be installed as a NPM dependency.

Electron binary is fairly big itself (about 200MB on Mac, compared to about 100MB for Node.js) since it contains fair amount of extra stuff besides just Node.js build but it's not relevant for memory usage at runtime.

For reference, on Mac, the LSP-typescript running on a VSCode repo with a bunch of files opened uses following amounts of memory:
 - 210MB when running on the official Node.js build
 - 142MB when running on Electron's Node.js build