### PR TITLE
fix(node): improve handling on "broken" Windows installations

### DIFF
--- a/st3/lsp_utils/helpers.py
+++ b/st3/lsp_utils/helpers.py
@@ -32,7 +32,12 @@ def run_command_sync(
                 env.update(extra_env)
             if extra_paths:
                 env['PATH'] = os.path.pathsep.join(extra_paths) + os.path.pathsep + env['PATH']
-        output = subprocess.check_output(args, cwd=cwd, shell=shell, stderr=subprocess.STDOUT, env=env)
+        startupinfo = None
+        if is_windows:
+            startupinfo = subprocess.STARTUPINFO()  # type: ignore
+            startupinfo.dwFlags |= subprocess.SW_HIDE | subprocess.STARTF_USESHOWWINDOW  # type: ignore
+        output = subprocess.check_output(
+            args, cwd=cwd, shell=shell, stderr=subprocess.STDOUT, env=env, startupinfo=startupinfo)
         return (decode_bytes(output).strip(), None)
     except subprocess.CalledProcessError as error:
         return ('', decode_bytes(error.output).strip())

--- a/st3/lsp_utils/helpers.py
+++ b/st3/lsp_utils/helpers.py
@@ -7,9 +7,15 @@ import threading
 StringCallback = Callable[[str], None]
 SemanticVersion = Tuple[int, int, int]
 
+is_windows = sublime.platform() == 'windows'
+
 
 def run_command_sync(
-    args: List[str], cwd: Optional[str] = None, extra_env: Optional[Dict[str, str]] = None, extra_paths: List[str] = []
+    args: List[str],
+    cwd: Optional[str] = None,
+    extra_env: Optional[Dict[str, str]] = None,
+    extra_paths: List[str] = [],
+    shell: bool = is_windows,
 ) -> Tuple[str, Optional[str]]:
     """
     Runs the given command synchronously.
@@ -26,8 +32,7 @@ def run_command_sync(
                 env.update(extra_env)
             if extra_paths:
                 env['PATH'] = os.path.pathsep.join(extra_paths) + os.path.pathsep + env['PATH']
-        output = subprocess.check_output(
-            args, cwd=cwd, shell=sublime.platform() == 'windows', stderr=subprocess.STDOUT, env=env)
+        output = subprocess.check_output(args, cwd=cwd, shell=shell, stderr=subprocess.STDOUT, env=env)
         return (decode_bytes(output).strip(), None)
     except subprocess.CalledProcessError as error:
         return ('', decode_bytes(error.output).strip())

--- a/st3/lsp_utils/node_runtime.py
+++ b/st3/lsp_utils/node_runtime.py
@@ -160,11 +160,12 @@ class NodeRuntime:
             return self._version
         if not self._node:
             raise Exception('Node.js not initialized')
-        version, error = run_command_sync([self._node, '--version'], extra_env=self.node_env())
+        # In this case we have fully resolved binary path already so shouldn't need `shell` on Windows.
+        version, error = run_command_sync([self._node, '--version'], extra_env=self.node_env(), shell=False)
         if error is None:
             self._version = Version(version.replace('v', ''))
         else:
-            raise Exception('Error resolving Node.js version:\n{}'.format(error))
+            raise Exception('Failed resolving Node.js version. Error:\n{}'.format(error))
         return self._version
 
     def run_node(
@@ -200,7 +201,9 @@ class NodeRuntime:
             '--verbose',
         ]
         stdout, error = run_command_sync(
-            self.npm_command() + args, cwd=cwd, extra_env=self.node_env(), extra_paths=self._additional_paths)
+            self.npm_command() + args, cwd=cwd, extra_env=self.node_env(), extra_paths=self._additional_paths,
+            shell=False
+        )
         print('[lsp_utils] START output of command: "{}"'.format(' '.join(args)))
         print(stdout)
         print('[lsp_utils] Command output END')
@@ -400,7 +403,9 @@ class ElectronRuntimeLocal(NodeRuntime):
             raise Exception('Specified working directory "{}" does not exist'.format(cwd))
         if not self._node:
             raise Exception('Node.js not installed. Use NodeInstaller to install it first.')
-        stdout, error = run_command_sync([self._node, self._yarn] + args, cwd=cwd, extra_env=self.node_env())
+        stdout, error = run_command_sync(
+            [self._node, self._yarn] + args, cwd=cwd, extra_env=self.node_env(), shell=False
+        )
         print('[lsp_utils] START output of command: "{}"'.format(' '.join(args)))
         print(stdout)
         print('[lsp_utils] Command output END')


### PR DESCRIPTION
On some "broken" Windows installations, running subprocess with shell=True can result in error exit code being returned from "node --version" even though node itself completes successfully.

This was reported few times and one time the culprit was an AutuRun script that made non-interactive shell executions result in exiting with error code.

Since our paths are fully resolved with shutil.which, we shouldn't need the side effect of shell=True that makes PATH being inherited from the system.

Fixes #100