### PR TITLE
fix(node): cleanup storage for no longer used servers and runtimes

### DIFF
--- a/st3/lsp_utils/node_runtime.py
+++ b/st3/lsp_utils/node_runtime.py
@@ -98,6 +98,12 @@ class NodeRuntime:
                             log_lines.append(' * Download skipped')
                             continue
                     try:
+                        # Remove outdated runtimes.
+                        if path.isdir(runtime_dir):
+                            for directory in next(os.walk(runtime_dir))[1]:
+                                old_dir = path.join(runtime_dir, directory)
+                                print('[lsp_utils] Deleting outdated Node.js runtime directory "{}"'.format(old_dir))
+                                shutil.rmtree(old_dir)
                         local_runtime.install_node()
                     except Exception as ex:
                         log_lines.append(' * Failed downloading: {}'.format(ex))


### PR DESCRIPTION
The package storage for a given LSP-* package will essentially get all subdirectories removed on installing a new version of the server so the cleanup will be done on starting particular servers rather than everything at once.

Resolves #90