### PR TITLE
fix: deleting old runtime shouldn't emit an exception

### DIFF
--- a/st3/lsp_utils/generic_client_handler.py
+++ b/st3/lsp_utils/generic_client_handler.py
@@ -1,5 +1,6 @@
 from ._client_handler import ClientHandler
 from .api_wrapper_interface import ApiWrapperInterface
+from .helpers import rmtree_ex
 from .server_resource_interface import ServerResourceInterface
 from abc import ABCMeta
 from LSP.plugin import ClientConfig
@@ -8,7 +9,6 @@ from LSP.plugin import WorkspaceFolder
 from LSP.plugin.core.typing import Any, Dict, List, Optional, Tuple
 from package_control import events  # type: ignore
 import os
-import shutil
 import sublime
 
 __all__ = ['GenericClientHandler']
@@ -44,7 +44,7 @@ class GenericClientHandler(ClientHandler, metaclass=ABCMeta):
 
         def run_async() -> None:
             if os.path.isdir(cls.package_storage()):
-                shutil.rmtree(cls.package_storage())
+                rmtree_ex(cls.package_storage())
 
         if events.remove(cls.package_name):
             sublime.set_timeout_async(run_async, 1000)

--- a/st3/lsp_utils/helpers.py
+++ b/st3/lsp_utils/helpers.py
@@ -71,7 +71,7 @@ def rmtree_ex(path: str, ignore_errors=False) -> None:
     # On Windows, "shutil.rmtree" will raise file not found errors when deleting a long path (>255 chars).
     # See https://stackoverflow.com/a/14076169/4643765
     # See https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
-    path = '\\\\?\\{}'.format(path) if sublime.platform() == 'windows' else path
+    path = R'\\?\{}'.format(path) if sublime.platform() == 'windows' else path
     shutil.rmtree(path, ignore_errors)
 
 

--- a/st3/lsp_utils/helpers.py
+++ b/st3/lsp_utils/helpers.py
@@ -1,5 +1,6 @@
 from LSP.plugin.core.typing import Any, Callable, Dict, List, Optional, Tuple
 import os
+import shutil
 import sublime
 import subprocess
 import threading
@@ -64,6 +65,14 @@ def decode_bytes(data: bytes) -> str:
     Decodes provided bytes using `utf-8` decoding, ignoring potential decoding errors.
     """
     return data.decode('utf-8', 'ignore')
+
+
+def rmtree_ex(path: str, ignore_errors=False) -> None:
+    # On Windows, "shutil.rmtree" will raise file not found errors when deleting a long path (>255 chars).
+    # See https://stackoverflow.com/a/14076169/4643765
+    # See https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
+    path = '\\\\?\\{}'.format(path) if sublime.platform() == 'windows' else path
+    shutil.rmtree(path, ignore_errors)
 
 
 def version_to_string(version: SemanticVersion) -> str:

--- a/st3/lsp_utils/helpers.py
+++ b/st3/lsp_utils/helpers.py
@@ -67,7 +67,7 @@ def decode_bytes(data: bytes) -> str:
     return data.decode('utf-8', 'ignore')
 
 
-def rmtree_ex(path: str, ignore_errors=False) -> None:
+def rmtree_ex(path: str, ignore_errors: bool = False) -> None:
     # On Windows, "shutil.rmtree" will raise file not found errors when deleting a long path (>255 chars).
     # See https://stackoverflow.com/a/14076169/4643765
     # See https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation

--- a/st3/lsp_utils/node_runtime.py
+++ b/st3/lsp_utils/node_runtime.py
@@ -1,4 +1,5 @@
 from .constants import SETTINGS_FILENAME
+from .helpers import rmtree_ex
 from .helpers import run_command_sync
 from .helpers import SemanticVersion
 from .helpers import version_to_string
@@ -102,12 +103,8 @@ class NodeRuntime:
                         for directory in next(os.walk(runtime_dir))[1]:
                             old_dir = path.join(runtime_dir, directory)
                             print('[lsp_utils] Deleting outdated Node.js runtime directory "{}"'.format(old_dir))
-                            # On Windows, "shutil.rmtree" will raise file not found errors when deleting a long path (>255 chars).
-                            # See https://stackoverflow.com/a/14076169/4643765
-                            # See https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
-                            deletion_path = ('\\\\?\\' + old_dir) if sublime.platform() == 'windows' else old_dir
                             try:
-                                shutil.rmtree(deletion_path)
+                                rmtree_ex(old_dir)
                             except Exception as ex:
                                 log_lines.append(' * Failed deleting: {}'.format(ex))
                     try:

--- a/st3/lsp_utils/node_runtime.py
+++ b/st3/lsp_utils/node_runtime.py
@@ -435,7 +435,11 @@ class ElectronInstaller:
 
     def run(self) -> None:
         archive, url = self._node_archive()
-        print('[lsp_utils] Downloading Electron {} (Node.js runtime {}) from {}'.format(ELECTRON_RUNTIME_VERSION, ELECTRON_NODE_VERSION, url))
+        print(
+            '[lsp_utils] Downloading Electron {} (Node.js runtime {}) from {}'.format(
+                ELECTRON_RUNTIME_VERSION, ELECTRON_NODE_VERSION, url
+            )
+        )
         if not self._archive_exists(archive):
             self._download(url, archive)
         self._install(archive)

--- a/st3/lsp_utils/node_runtime.py
+++ b/st3/lsp_utils/node_runtime.py
@@ -431,7 +431,7 @@ class ElectronInstaller:
 
     def run(self) -> None:
         archive, url = self._node_archive()
-        print('[lsp_utils] Downloading Electron {} from {}'.format(ELECTRON_NODE_VERSION, url))
+        print('[lsp_utils] Downloading Electron {} (Node.js runtime {}) from {}'.format(ELECTRON_RUNTIME_VERSION, ELECTRON_NODE_VERSION, url))
         if not self._archive_exists(archive):
             self._download(url, archive)
         self._install(archive)

--- a/st3/lsp_utils/node_runtime.py
+++ b/st3/lsp_utils/node_runtime.py
@@ -97,13 +97,20 @@ class NodeRuntime:
                                 NO_NODE_FOUND_MESSAGE.format(package_name=package_name), 'Download Node.js'):
                             log_lines.append(' * Download skipped')
                             continue
+                    # Remove outdated runtimes.
+                    if path.isdir(runtime_dir):
+                        for directory in next(os.walk(runtime_dir))[1]:
+                            old_dir = path.join(runtime_dir, directory)
+                            print('[lsp_utils] Deleting outdated Node.js runtime directory "{}"'.format(old_dir))
+                            # On Windows, "shutil.rmtree" will raise file not found errors when deleting a long path (>255 chars).
+                            # See https://stackoverflow.com/a/14076169/4643765
+                            # See https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
+                            deletion_path = ('\\\\?\\' + old_dir) if sublime.platform() == 'windows' else old_dir
+                            try:
+                                shutil.rmtree(deletion_path)
+                            except Exception as ex:
+                                log_lines.append(' * Failed deleting: {}'.format(ex))
                     try:
-                        # Remove outdated runtimes.
-                        if path.isdir(runtime_dir):
-                            for directory in next(os.walk(runtime_dir))[1]:
-                                old_dir = path.join(runtime_dir, directory)
-                                print('[lsp_utils] Deleting outdated Node.js runtime directory "{}"'.format(old_dir))
-                                shutil.rmtree(old_dir)
                         local_runtime.install_node()
                     except Exception as ex:
                         log_lines.append(' * Failed downloading: {}'.format(ex))

--- a/st3/lsp_utils/server_npm_resource.py
+++ b/st3/lsp_utils/server_npm_resource.py
@@ -1,4 +1,3 @@
-from shutil import rmtree
 from .helpers import rmtree_ex
 from .helpers import SemanticVersion
 from .node_runtime import NodeRuntime

--- a/st3/lsp_utils/server_npm_resource.py
+++ b/st3/lsp_utils/server_npm_resource.py
@@ -1,3 +1,5 @@
+from shutil import rmtree
+from .helpers import rmtree_ex
 from .helpers import SemanticVersion
 from .node_runtime import NodeRuntime
 from .server_resource_interface import ServerResourceInterface
@@ -8,7 +10,6 @@ from os import makedirs
 from os import path
 from os import remove
 from os import walk
-from shutil import rmtree
 from sublime_lib import ResourcePath
 
 __all__ = ['ServerNpmResource']
@@ -117,7 +118,7 @@ class ServerNpmResource(ServerResourceInterface):
             makedirs(path.dirname(self._installation_marker_file), exist_ok=True)
             open(self._installation_marker_file, 'a').close()
             if path.isdir(self._server_dest):
-                rmtree(self._server_dest)
+                rmtree_ex(self._server_dest)
             ResourcePath(self._server_src).copytree(self._server_dest, exist_ok=True)
             if not self._skip_npm_install:
                 self._node_runtime.run_install(cwd=self._server_dest)
@@ -137,4 +138,4 @@ class ServerNpmResource(ServerResourceInterface):
                 continue
             node_storage_path = path.join(self._package_storage, directory)
             print('[lsp_utils] Deleting outdated storage directory "{}"'.format(node_storage_path))
-            rmtree(node_storage_path)
+            rmtree_ex(node_storage_path)

--- a/st3/lsp_utils/server_pip_resource.py
+++ b/st3/lsp_utils/server_pip_resource.py
@@ -1,3 +1,4 @@
+from .helpers import rmtree_ex
 from .helpers import run_command_sync
 from .server_resource_interface import ServerResourceInterface
 from .server_resource_interface import ServerStatus
@@ -6,7 +7,6 @@ from LSP.plugin.core.typing import Any, Optional
 from os import path
 from sublime_lib import ResourcePath
 import os
-import shutil
 import sublime
 
 __all__ = ['ServerPipResource']
@@ -94,7 +94,7 @@ class ServerPipResource(ServerResourceInterface):
         return False
 
     def install_or_update(self) -> None:
-        shutil.rmtree(self.basedir(), ignore_errors=True)
+        rmtree_ex(self.basedir(), ignore_errors=True)
         try:
             os.makedirs(self.basedir(), exist_ok=True)
             self.run(self._python_binary, '-m', 'venv', self._package_name, cwd=self._storage_path)


### PR DESCRIPTION
Resolves https://github.com/sublimelsp/lsp_utils/issues/109

That deletion shouldn't in the try...catch block because its exception is not for ` * Failed downloading: ...` but due to locked files. This is quite confusing in the error log.

`ignore_errors=True` for `shutil.rmtree()` is being added too so that at least the whole procedure can go on (install runtime, invoke servers etc).