### PR TITLE
feat: add support for specifying path to node in settings

### DIFF
--- a/st3/lsp_utils/node_runtime.py
+++ b/st3/lsp_utils/node_runtime.py
@@ -246,6 +246,7 @@ class NodeRuntimeAbsolute(NodeRuntime):
         self._base_dir = path.abspath(path.dirname(node_binary))
         self._node = path.join(self._base_dir, 'node')
         self._npm = path.join(self._base_dir, 'npm')
+        self._additional_paths = [path.dirname(self._node)] if self._node else []
 
 class NodeRuntimePATH(NodeRuntime):
     def __init__(self) -> None:

--- a/st3/lsp_utils/node_runtime.py
+++ b/st3/lsp_utils/node_runtime.py
@@ -123,6 +123,20 @@ class NodeRuntime:
                     break
                 except Exception as ex:
                     log_lines.append(' * {}'.format(ex))
+            elif path.basename(runtime_type) == 'node':
+                log_lines.append('Resolving Node.js Runtime from absolute path for package {}...'.format(package_name))
+                path_runtime = NodeRuntimeAbsolute(runtime_type)
+                try:
+                    path_runtime.check_binary_present()
+                except Exception as ex:
+                    log_lines.append(' * Failed: {}'.format(ex))
+                    continue
+                try:
+                    path_runtime.check_satisfies_version(required_node_version)
+                    resolved_runtime = path_runtime
+                    break
+                except Exception as ex:
+                    log_lines.append(' * {}'.format(ex))
         if not resolved_runtime:
             log_lines.append('--- lsp_utils Node.js resolving end ---')
             print('\n'.join(log_lines))
@@ -225,6 +239,13 @@ class NodeRuntime:
             raise Exception('Npm command not initialized')
         return [self._npm]
 
+
+class NodeRuntimeAbsolute(NodeRuntime):
+    def __init__(self, node_binary: str):
+        super().__init__()
+        self._base_dir = path.abspath(path.dirname(node_binary))
+        self._node = path.join(self._base_dir, 'node')
+        self._npm = path.join(self._base_dir, 'npm')
 
 class NodeRuntimePATH(NodeRuntime):
     def __init__(self) -> None:


### PR DESCRIPTION
This pull request adds support for specifying a path to a `node` binary. I've found that `system` can be unreliable when using tools like `nodenv` (even with proper `.zprofile` setup), so this change lets a user specify any node binary to be used with LSP plugins.

I've also submitted a PR to update the `lsp_utils.sublime-settings`: [sublimelsp/LSP#2464](https://github.com/sublimelsp/LSP/pull/2464)

**Caveat:** This change assumes that an `npm` binary exists in the same directory as `node`; in my research it seems that all installations of Node.js follow this principle, so it should be a non-issue.