### PR TITLE
fix: additional paths shouldn't be duplicated every time a new session starts

### DIFF
--- a/st3/lsp_utils/_client_handler/abstract_plugin.py
+++ b/st3/lsp_utils/_client_handler/abstract_plugin.py
@@ -128,19 +128,19 @@ class ClientHandler(AbstractPlugin, ClientHandlerInterface):
     @classmethod
     def on_pre_start(cls, window: sublime.Window, initiating_view: sublime.View,
                      workspace_folders: List[WorkspaceFolder], configuration: ClientConfig) -> Optional[str]:
-        original_path_raw = configuration.env.get('PATH') or ''
-        if isinstance(original_path_raw, str):
-            original_paths = original_path_raw.split(path.pathsep)
-        else:
-            original_paths = original_path_raw
-
-        # To fix https://github.com/TerminalFi/LSP-copilot/issues/163 ,
-        # We don't want to add the same path multiple times whenever a new server session is created.
-        # Note that additional paths should be prepended to the original paths.
-        wanted_paths = [path for path in cls.get_additional_paths() if path not in original_paths]
-        wanted_paths.extend(original_paths)
-        configuration.env['PATH'] = path.pathsep.join(wanted_paths)
-
+        extra_paths = cls.get_additional_paths()
+        if extra_paths:
+            original_path_raw = configuration.env.get('PATH') or ''
+            if isinstance(original_path_raw, str):
+                original_paths = original_path_raw.split(path.pathsep)
+            else:
+                original_paths = original_path_raw
+            # To fix https://github.com/TerminalFi/LSP-copilot/issues/163 ,
+            # We don't want to add the same path multiple times whenever a new server session is created.
+            # Note that additional paths should be prepended to the original paths.
+            wanted_paths = [path for path in extra_paths if path not in original_paths]
+            wanted_paths.extend(original_paths)
+            configuration.env['PATH'] = path.pathsep.join(wanted_paths)
         return None
 
     # --- ClientHandlerInterface --------------------------------------------------------------------------------------

--- a/st3/lsp_utils/_client_handler/abstract_plugin.py
+++ b/st3/lsp_utils/_client_handler/abstract_plugin.py
@@ -1,6 +1,5 @@
 from .._util import weak_method
 from ..api_wrapper_interface import ApiWrapperInterface
-from ..helpers import unique_everseen
 from ..server_resource_interface import ServerStatus
 from .api_decorator import register_decorated_handlers
 from .interface import ClientHandlerInterface
@@ -16,7 +15,6 @@ from LSP.plugin import unregister_plugin
 from LSP.plugin import WorkspaceFolder
 from LSP.plugin.core.rpc import method2attr
 from LSP.plugin.core.typing import Any, Callable, Dict, List, Optional, Tuple, TypedDict
-from itertools import chain
 from os import path
 from weakref import ref
 import sublime
@@ -130,16 +128,19 @@ class ClientHandler(AbstractPlugin, ClientHandlerInterface):
     @classmethod
     def on_pre_start(cls, window: sublime.Window, initiating_view: sublime.View,
                      workspace_folders: List[WorkspaceFolder], configuration: ClientConfig) -> Optional[str]:
+        original_path_raw = configuration.env.get('PATH') or ''
+        if isinstance(original_path_raw, str):
+            original_paths = original_path_raw.split(path.pathsep)
+        else:
+            original_paths = original_path_raw
+
         # To fix https://github.com/TerminalFi/LSP-copilot/issues/163 ,
         # We don't want to add the same path multiple times whenever a new server session is created.
-        extra_paths = cls.get_additional_paths()
-        if extra_paths:
-            original_path_raw = configuration.env.get('PATH') or ''
-            if isinstance(original_path_raw, str):
-                original_paths = original_path_raw.split(path.pathsep)
-            else:
-                original_paths = original_path_raw
-            configuration.env['PATH'] = path.pathsep.join(unique_everseen(chain(extra_paths, original_paths)))
+        # Note that additional paths should be prepended to the original paths.
+        wanted_paths = [path for path in cls.get_additional_paths() if path not in original_paths]
+        wanted_paths.extend(original_paths)
+        configuration.env['PATH'] = path.pathsep.join(wanted_paths)
+
         return None
 
     # --- ClientHandlerInterface --------------------------------------------------------------------------------------

--- a/st3/lsp_utils/helpers.py
+++ b/st3/lsp_utils/helpers.py
@@ -1,11 +1,9 @@
-from LSP.plugin.core.typing import Any, Callable, Dict, Generator, Iterable, List, Optional, Set, Tuple, TypeVar
+from LSP.plugin.core.typing import Any, Callable, Dict, List, Optional, Tuple
 import os
 import shutil
 import sublime
 import subprocess
 import threading
-
-_T = TypeVar('_T')
 
 StringCallback = Callable[[str], None]
 SemanticVersion = Tuple[int, int, int]
@@ -95,46 +93,3 @@ def log_and_show_message(message: str, additional_logs: Optional[str] = None, sh
     print(message, '\n', additional_logs) if additional_logs else print(message)
     if show_in_status:
         sublime.active_window().status_message(message)
-
-
-def unique_everseen(iterable: Iterable[_T], key: Optional[Callable[[_T], Any]] = None) -> Generator[_T, None, None]:
-    """
-    Yield unique elements, preserving order.
-
-        >>> list(unique_everseen('AAAABBBCCDAABBB'))
-        ['A', 'B', 'C', 'D']
-        >>> list(unique_everseen('ABBCcAD', str.lower))
-        ['A', 'B', 'C', 'D']
-
-    Sequences with a mix of hashable and unhashable items can be used.
-    The function will be slower (i.e., `O(n^2)`) for unhashable items.
-
-    Remember that ``list`` objects are unhashable - you can use the *key*
-    parameter to transform the list to a tuple (which is hashable) to
-    avoid a slowdown.
-
-        >>> iterable = ([1, 2], [2, 3], [1, 2])
-        >>> list(unique_everseen(iterable))  # Slow
-        [[1, 2], [2, 3]]
-        >>> list(unique_everseen(iterable, key=tuple))  # Faster
-        [[1, 2], [2, 3]]
-
-    Similarly, you may want to convert unhashable ``set`` objects with
-    ``key=frozenset``. For ``dict`` objects,
-    ``key=lambda x: frozenset(x.items())`` can be used.
-    """
-    seenset: Set[Any] = set()
-    seenset_add = seenset.add
-    seenlist: List[Any] = []
-    seenlist_add = seenlist.append
-
-    for element in iterable:
-        k = element if key is None else key(element)
-        try:
-            if k not in seenset:
-                seenset_add(k)
-                yield element
-        except TypeError:
-            if k not in seenlist:
-                seenlist_add(k)
-                yield element


### PR DESCRIPTION
`configuration.env['PATH']` is bound to a server class and we just keep prepending the same additional paths into it every time when there is a new session starts (e.g., a project is opened in a new window). Eventually, it triggers this bug: https://github.com/TerminalFi/LSP-copilot/issues/163