### PR TITLE
fix: package control can be an optional dependency

### DIFF
--- a/st3/lsp_utils/generic_client_handler.py
+++ b/st3/lsp_utils/generic_client_handler.py
@@ -7,7 +7,6 @@ from LSP.plugin import ClientConfig
 from LSP.plugin import DottedDict
 from LSP.plugin import WorkspaceFolder
 from LSP.plugin.core.typing import Any, Dict, List, Optional, Tuple
-from package_control import events  # type: ignore
 import os
 import sublime
 
@@ -46,8 +45,13 @@ class GenericClientHandler(ClientHandler, metaclass=ABCMeta):
             if os.path.isdir(cls.package_storage()):
                 rmtree_ex(cls.package_storage())
 
-        if events.remove(cls.package_name):
-            sublime.set_timeout_async(run_async, 1000)
+        try:
+            from package_control import events  # type: ignore
+            if events.remove(cls.package_name):
+                sublime.set_timeout_async(run_async, 1000)
+        except ImportError:
+            pass  # Package Control is not required.
+
         super().cleanup()
 
     @classmethod


### PR DESCRIPTION
This change refactors the package control dependency to be optional by catching the import error if package control is not available and making it an no-op operation.

Previously the import error at the top prevented LSP utils from working properly when package control was not available.