### PR TITLE
fix: update optionality of the is_allowed_to_start() method

### DIFF
--- a/st3/lsp_utils/_client_handler/interface.py
+++ b/st3/lsp_utils/_client_handler/interface.py
@@ -84,9 +84,9 @@ class ClientHandlerInterface(metaclass=ABCMeta):
     def is_allowed_to_start(
         cls,
         window: sublime.Window,
-        initiating_view: Optional[sublime.View] = None,
-        workspace_folders: Optional[List[WorkspaceFolder]] = None,
-        configuration: Optional[ClientConfig] = None
+        initiating_view: sublime.View,
+        workspace_folders: List[WorkspaceFolder],
+        configuration: ClientConfig,
     ) -> Optional[str]:
         ...
 

--- a/st3/lsp_utils/generic_client_handler.py
+++ b/st3/lsp_utils/generic_client_handler.py
@@ -174,9 +174,9 @@ class GenericClientHandler(ClientHandler, metaclass=ABCMeta):
     def is_allowed_to_start(
         cls,
         window: sublime.Window,
-        initiating_view: Optional[sublime.View] = None,
-        workspace_folders: Optional[List[WorkspaceFolder]] = None,
-        configuration: Optional[ClientConfig] = None
+        initiating_view: sublime.View,
+        workspace_folders: List[WorkspaceFolder],
+        configuration: ClientConfig,
     ) -> Optional[str]:
         """
         Determines if the session is allowed to start.


### PR DESCRIPTION
Those are not optional. I think the reason it was like that was to support the legacy interface that is now removed.