### PR TITLE
fix: switch to `py` for running python on Windows

### DIFF
--- a/st3/lsp_utils/pip_client_handler.py
+++ b/st3/lsp_utils/pip_client_handler.py
@@ -48,10 +48,9 @@ class PipClientHandler(GenericClientHandler):
         """
         Returns a binary name or a full path to the Python interpreter used to create environment for the server.
 
-        The default implementation returns `python` on Windows and `python3` on other platforms. When only the binary
-        name is specified then it will be expected that it can be found on the PATH.
+        When only the binary name is specified then it will be expected that it can be found on the PATH.
         """
-        return 'python' if sublime.platform() == 'windows' else 'python3'
+        return 'py' if sublime.platform() == 'windows' else 'python3'
 
     # --- GenericClientHandler handlers -------------------------------------------------------------------------------
 

--- a/tests/test_smoketest.py
+++ b/tests/test_smoketest.py
@@ -18,6 +18,7 @@ class BaseTestCase(TextDocumentTestCase):
             self.assertIsNotNone(session_view)
             error_region_key = '{}_icon'.format(session_view.diagnostics_key(1, multiline=False))
             yield {'condition': lambda: len(session_view.session_buffer.diagnostics) == 1, 'timeout': TIMEOUT_TIME * 4}
+            print(session_view.session_buffer.diagnostics)
         error_regions = self.view.get_regions(error_region_key)
         self.assertEqual(len(error_regions), 1)
         region = error_regions[0]

--- a/tests/test_smoketest.py
+++ b/tests/test_smoketest.py
@@ -18,7 +18,7 @@ class BaseTestCase(TextDocumentTestCase):
             self.assertIsNotNone(session_view)
             error_region_key = '{}_icon'.format(session_view.diagnostics_key(1, multiline=False))
             yield {'condition': lambda: len(session_view.session_buffer.diagnostics) == 1, 'timeout': TIMEOUT_TIME * 4}
-        error_regions = yield lambda: self.view.get_regions(error_region_key)
+        error_regions = self.view.get_regions(error_region_key)
         self.assertEqual(len(error_regions), 1)
         region = error_regions[0]
         self.assertEqual((region.a, region.b), (6, 7))


### PR DESCRIPTION
I'm probably not gonna test it myself. If someone is able then please do and report back.

Resolves #121