### PR TITLE
ui: respect the silence as defined in user LSP settings

### DIFF
--- a/st4_py38/lsp_utils/node_runtime.py
+++ b/st4_py38/lsp_utils/node_runtime.py
@@ -94,6 +94,11 @@ class NodeRuntime:
                 except Exception as ex:
                     log_lines.append(' * Binaries check failed: {}'.format(ex))
                     if selected_runtimes[0] != 'local':
+                        lsp_cfg = sublime.load_settings('LSP.sublime-settings')
+                        suppress_error_dialogs = cast(bool, lsp_cfg.get('suppress_error_dialogs') or False)
+                        if suppress_error_dialogs:
+                            log_lines.append(' * Download auto-skipped due to "suppress_error_dialogs" setting')
+                            continue
                         if not sublime.ok_cancel_dialog(
                                 NO_NODE_FOUND_MESSAGE.format(package_name=package_name), 'Download Node.js'):
                             log_lines.append(' * Download skipped')


### PR DESCRIPTION
LSP is [planning to add](https://github.com/sublimelsp/LSP/pull/2546) a user setting allowing for an uniterrupted user experience on various less-than-critical errors.

However, lsp_utils still asks for download in case some local node-resolution failed. This PR checks whether the user has opted into no interruptions in their LSP config and auto-cancels the download and the download prompt with a custom console log message specifying which setting is responsible

LSP will notify via statusbar that the server failed, so no need for an extra status notification in this package


addresses https://github.com/sublimelsp/LSP/issues/2545
