### PR TITLE
fix: update node version to latest LTS (22.18.0)

### DIFF
--- a/st4_py38/lsp_utils/node_runtime.py
+++ b/st4_py38/lsp_utils/node_runtime.py
@@ -23,11 +23,11 @@ __all__ = ['NodeRuntime']
 
 IS_WINDOWS_7_OR_LOWER = sys.platform == 'win32' and sys.getwindowsversion()[:2] <= (6, 1)  # type: ignore
 
-NODE_RUNTIME_VERSION = '20.18.0'
+NODE_RUNTIME_VERSION = '22.18.0'
 NODE_DIST_URL = 'https://nodejs.org/dist/v{version}/{filename}'
 
-ELECTRON_RUNTIME_VERSION = '33.0.0'  # includes Node.js v20.18.0
-ELECTRON_NODE_VERSION = '20.18.0'
+ELECTRON_RUNTIME_VERSION = '36.8.0'
+ELECTRON_NODE_VERSION = '22.18.0'
 ELECTRON_DIST_URL = 'https://github.com/electron/electron/releases/download/v{version}/{filename}'
 YARN_URL = 'https://github.com/yarnpkg/yarn/releases/download/v1.22.22/yarn-1.22.22.js'
 


### PR DESCRIPTION
Figured that as we're doing #133 which will cause packages to get npm packages to get reinstalled, we might as well bump Node to the latest LTS version.

While Node 24 will be LTS soon, Electron didn't adopt it yet so we're sticking with the latest version of Node 22 for consistency.