### PR TITLE
feat: expose HOST_ARCH and support running node on arm64 windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # caches
+.DS_Store
 __pycache__
 .mypy_cache
 *.pickle

--- a/lsp_utils/__init__.py
+++ b/lsp_utils/__init__.py
@@ -6,6 +6,7 @@ from ._client_handler import request_handler
 from ._util import download_file
 from ._util import extract_archive
 from .api_wrapper_interface import ApiWrapperInterface
+from .constants import HOST_ARCH
 from .constants import SETTINGS_FILENAME
 from .generic_client_handler import GenericClientHandler
 from .helpers import rmtree_ex
@@ -20,6 +21,7 @@ from .uv_runner import UvRunner
 from .uv_venv_manager import UvVenvManager
 
 __all__ = [
+    'HOST_ARCH',
     'SETTINGS_FILENAME',
     'ApiWrapperInterface',
     'ClientHandler',

--- a/lsp_utils/_util/__init__.py
+++ b/lsp_utils/_util/__init__.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 from .download_file import download_file
 from .download_file import extract_archive
+from .host_arch import get_host_arch
 from .logging import logger
 
 __all__ = [
     'download_file',
     'extract_archive',
+    'get_host_arch',
     'logger',
 ]

--- a/lsp_utils/_util/download_file.py
+++ b/lsp_utils/_util/download_file.py
@@ -21,14 +21,15 @@ def download_file(url: str, target_path: Path) -> None:
         copyfileobj(response, out_file)
 
 
-def extract_archive(archive_file: Path, target_directory: Path) -> Path:
+def extract_archive(archive_file: Path, target_directory: Path) -> Path | None:
     """
     Extract all files from an archive.
 
     :param archive_file: Path to the archive file to extract.
     :param target_directory: Directory where files will be extracted.
-    :return: Path to the extracted directory. If the archive contains a single
-             root directory, the returned path will include that directory.
+    :return: Path to the top-level directory within extracted files or `None`.
+             If the archive contains all files in a single root directory then returns path to that directory.
+             If there is no single parent then returns `None` (means that files are directly under `target_directory`).
     """
     archive_name = archive_file.name
     if archive_name.endswith('.zip'):
@@ -42,7 +43,7 @@ def extract_archive(archive_file: Path, target_directory: Path) -> Path:
         raise Exception(msg)
 
 
-def extract_files_from_archive(archive: ZipFile | tarfile.TarFile, target_directory: Path) -> Path:
+def extract_files_from_archive(archive: ZipFile | tarfile.TarFile, target_directory: Path) -> Path | None:
     names = archive.namelist() if isinstance(archive, ZipFile) else archive.getnames()
     bad_members = [x for x in names if x.startswith(('/', '..'))]
     if bad_members:
@@ -50,9 +51,7 @@ def extract_files_from_archive(archive: ZipFile | tarfile.TarFile, target_direct
         raise Exception(msg)
     topdir_name = get_top_level_directory(names)
     archive.extractall(str(target_directory))  # noqa: S202
-    if topdir_name:
-        return target_directory / topdir_name
-    return target_directory
+    return target_directory / topdir_name if topdir_name else None
 
 
 def get_top_level_directory(names: list[str]) -> str | None:

--- a/lsp_utils/_util/download_file.py
+++ b/lsp_utils/_util/download_file.py
@@ -51,7 +51,10 @@ def extract_files_from_archive(archive: ZipFile | tarfile.TarFile, target_direct
         raise Exception(msg)
     topdir_name = get_top_level_directory(names)
     archive.extractall(str(target_directory))  # noqa: S202
-    return target_directory / topdir_name if topdir_name else None
+    topdir_path = target_directory / topdir_name if topdir_name else None
+    if topdir_path and topdir_path.is_dir():
+        return topdir_path
+    return None
 
 
 def get_top_level_directory(names: list[str]) -> str | None:

--- a/lsp_utils/_util/host_arch.py
+++ b/lsp_utils/_util/host_arch.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from enum import IntEnum
+from typing import cast
+from typing import Literal
+import ctypes
+import sublime
+
+Architecture = Literal["x32", "x64", "arm64"]
+
+
+class ImageFileMachine(IntEnum):
+    IMAGE_FILE_MACHINE_AMD64 = 0x8664
+    IMAGE_FILE_MACHINE_ARM64 = 0xAA64
+    IMAGE_FILE_MACHINE_I386 = 0x014C
+    IMAGE_FILE_MACHINE_UNKNOWN = 0x0000
+
+
+MACHINE_NAMES: dict[ImageFileMachine, Architecture] = {
+    ImageFileMachine.IMAGE_FILE_MACHINE_AMD64: "x64",
+    ImageFileMachine.IMAGE_FILE_MACHINE_ARM64: "arm64",
+    ImageFileMachine.IMAGE_FILE_MACHINE_I386: "x32",
+    ImageFileMachine.IMAGE_FILE_MACHINE_UNKNOWN: "x64",
+}
+
+
+def get_host_arch() -> Architecture:
+    if sublime.platform() == "windows":
+        kernel32 = ctypes.windll.kernel32
+        c_ushort_p = ctypes.POINTER(ctypes.c_ushort)
+        kernel32.IsWow64Process2.argtypes = (ctypes.c_void_p, c_ushort_p, c_ushort_p)
+        process_machine = ctypes.c_ushort(0)
+        native_machine = ctypes.c_ushort(0)
+        success = kernel32.IsWow64Process2(
+            kernel32.GetCurrentProcess(), ctypes.byref(process_machine), ctypes.byref(native_machine))
+        if success:
+            return MACHINE_NAMES[cast("ImageFileMachine", native_machine.value)]
+    return sublime.arch()

--- a/lsp_utils/constants.py
+++ b/lsp_utils/constants.py
@@ -1,3 +1,6 @@
 from __future__ import annotations
 
+from ._util import get_host_arch
+
+HOST_ARCH = get_host_arch()
 SETTINGS_FILENAME = 'lsp_utils.sublime-settings'

--- a/lsp_utils/node_runtime.py
+++ b/lsp_utils/node_runtime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from ._util import download_file
 from ._util import extract_archive
 from ._util import logger
+from .constants import HOST_ARCH
 from .constants import SETTINGS_FILENAME
 from .helpers import rmtree_ex
 from .helpers import run_command_sync
@@ -10,14 +11,12 @@ from .helpers import SemanticVersion
 from .helpers import version_to_string
 from .third_party.semantic_version import NpmSpec  # pyright: ignore[reportPrivateLocalImportUsage]
 from .third_party.semantic_version import Version  # pyright: ignore[reportPrivateLocalImportUsage]
-from contextlib import contextmanager
 from LSP.plugin.core.logging import debug
 from pathlib import Path
 from sublime_lib import ActivityIndicator
 from typing import Any
 from typing import cast
 from typing import final
-from typing import Generator
 from typing_extensions import override
 import os
 import shutil
@@ -131,6 +130,7 @@ class NodeRuntime:
                     log_lines.append(f' * {ex}')
         if not resolved_runtime:
             log_lines.append('--- lsp_utils Node.js resolving end ---')
+            logger.debug('\n'.join(log_lines))
             msg = 'Failed resolving Node.js Runtime. Please check in the console for more details.'
             raise Exception(msg)
         return resolved_runtime
@@ -280,7 +280,6 @@ class NodeRuntimeLocal(NodeRuntime):
         with ActivityIndicator(sublime.active_window(), '[LSP] Setting up local Node.js'):
             install_node = NodeInstaller(self._base_dir, self._node_version)
             install_node.run()
-            self._resolve_paths()
         self._install_in_progress_marker_file.unlink()
         self._resolve_paths()
 
@@ -339,8 +338,8 @@ class NodeInstaller:
 
     def _node_archive(self) -> tuple[str, str]:
         platform = sublime.platform()
-        arch = sublime.arch()
-        if platform == 'windows' and arch == 'x64':
+        arch = HOST_ARCH
+        if platform == 'windows':
             node_os = 'win'
             archive = 'zip'
         elif platform == 'linux':
@@ -357,8 +356,10 @@ class NodeInstaller:
         return filename, dist_url
 
     def _install_node(self, archive_path: Path) -> None:
-        install_directory = extract_archive(archive_path, self._base_dir)
-        install_directory.rename(install_directory.parent / 'node')
+        temporary_target_path = self._base_dir / 'node-temp'
+        extracted_path = extract_archive(archive_path, temporary_target_path) or temporary_target_path
+        extracted_path.rename(self._base_dir / 'node')
+        rmtree_ex(temporary_target_path, ignore_errors=True)
         archive_path.unlink()
 
 
@@ -462,7 +463,7 @@ class ElectronInstaller:
 
     def _node_archive(self) -> tuple[str, str]:
         platform = sublime.platform()
-        arch = sublime.arch()
+        arch = HOST_ARCH
         if platform == 'windows':
             platform_code = 'win32'
         elif platform == 'linux':
@@ -488,14 +489,3 @@ class ElectronInstaller:
                     raise Exception(msg)
         finally:
             archive_path.unlink()
-
-
-@contextmanager
-def chdir(new_dir: str) -> Generator[None, None, None]:
-    """Context Manager for changing the working directory."""
-    cur_dir = Path.cwd()
-    os.chdir(new_dir)
-    try:
-        yield
-    finally:
-        os.chdir(cur_dir)

--- a/lsp_utils/uv_runner.py
+++ b/lsp_utils/uv_runner.py
@@ -68,8 +68,9 @@ class UvRunner:
                 with TemporaryDirectory(dir=target_directory) as tempdir:
                     archive_path = Path(tempdir, filename)
                     download_file(url, archive_path)
-                    source_directory = extract_archive(archive_path, Path(tempdir))
-                    source_directory.joinpath(UV_BINARY).replace(target_uv_path)
+                    temporary_directory_path = Path(tempdir)
+                    extracted_path = extract_archive(archive_path, temporary_directory_path) or temporary_directory_path
+                    extracted_path.joinpath(UV_BINARY).replace(target_uv_path)
                     target_uv_path.chmod(0o744)
                     target_version_path.write_text(UV_TAG)
             self._uv = str(target_uv_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,14 +78,6 @@ skip-magic-trailing-comma = false
 # Automatically detect the appropriate line ending.
 line-ending = "auto"
 
-[tool.ruff.lint.isort]
-case-sensitive = false
-force-single-line = true
-from-first = true
-no-sections = true
-order-by-type = false
-required-imports = ["from __future__ import annotations"]
-
 [tool.ruff.lint]
 # Enable preview rules.
 preview = true
@@ -117,6 +109,14 @@ ignore = [
 	"TID252",  # https://docs.astral.sh/ruff/rules/relative-imports/
 	"TRY002",  # https://docs.astral.sh/ruff/rules/raise-vanilla-class/
 ]
+
+[tool.ruff.lint.isort]
+case-sensitive = false
+force-single-line = true
+from-first = true
+no-sections = true
+order-by-type = false
+required-imports = ["from __future__ import annotations"]
 
 [tool.tox]
 env_list = ["py3"]


### PR DESCRIPTION
When running on arm64 Windows, we'll start arm64 build of node/electron. Previously it would always run x86 build in that case because ST doesn't have arm64 build and we've checked the architecture of ST and not OS.

Also some behavior change to `extract_archive` but nothing used it externally so it's safe.