### PR TITLE
fix(node): avoid calling `node --version` for local node

### DIFF
--- a/lsp_utils/_node/node_runner.py
+++ b/lsp_utils/_node/node_runner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from .._util import logger
 from ..constants import INSTALLING_MARKER_FILE
+from ..helpers import is_hash_equal
 from ..helpers import rmtree_ex
 from ..helpers import run_command_sync
 from ..helpers import start_process
@@ -9,7 +10,6 @@ from ..third_party.semantic_version import NpmSpec  # pyright: ignore[reportPriv
 from ..third_party.semantic_version import Version  # pyright: ignore[reportPrivateLocalImportUsage]
 from .node_constants import NODE_RUNTIME_VERSION
 from .node_installer import NodeInstaller
-from hashlib import md5
 from pathlib import Path
 from sublime_lib import ActivityIndicator
 from typing import Any
@@ -32,6 +32,10 @@ NODE_VERSION_MARKER_FILE = '.node-version'
 
 class NodeNotInitializedError(Exception):
     pass
+
+
+def create_version(version: str) -> Version:
+    return Version(version.replace('v', ''))
 
 
 class NodeRunner:
@@ -82,7 +86,7 @@ class NodeRunner:
         # In this case we have fully resolved binary path already so shouldn't need `shell` on Windows.
         version, error = run_command_sync([self._node, '--version'], extra_env=self.node_env(), shell=False)
         if error is None:
-            self._version = Version(version.replace('v', ''))
+            self._version = create_version(version)
         else:
             msg = f'Failed resolving Node.js version. Error:\n{error}'
             raise Exception(msg)
@@ -133,12 +137,18 @@ class NodeRunner:
         return [self._npm]
 
     def install_project_dependencies(self, source_path: ResourcePath, target_path: Path) -> None:
-        if self._are_project_dependencies_installed(source_path, target_path):
+        node_version = str(self.resolve_version())
+        if (
+            not (target_path / INSTALLING_MARKER_FILE).is_file()
+            and (target_path / 'node_modules').is_dir()
+            and is_hash_equal(source_path / 'package.json', target_path / 'package.json')
+            and (marker_file_path := target_path / NODE_VERSION_MARKER_FILE).is_file()
+            and node_version == marker_file_path.read_text(encoding='utf-8').strip()
+        ):
             return
         try:
             if target_path.is_dir():
                 rmtree_ex(target_path)
-            node_version = str(self.resolve_version())
             target_path.mkdir(exist_ok=True, parents=True)
             (target_path / INSTALLING_MARKER_FILE).open('w', encoding='utf-8').close()
             source_path.copytree(target_path, exist_ok=True)
@@ -147,32 +157,7 @@ class NodeRunner:
             (target_path / INSTALLING_MARKER_FILE).unlink()
         except Exception as error:
             msg = f'Error installing the server:\n{error}'
-            raise Exception(msg) from error
-
-    def _are_project_dependencies_installed(self, source_path: ResourcePath, target_path: Path) -> bool:
-        if not (target_path / 'node_modules').is_dir():
-            return False
-        # Server already installed. Check if version has changed or last installation did not complete.
-        src_package_json = source_path / 'package.json'
-        if not src_package_json.exists():
-            msg = f'Missing required "package.json" in {source_path}'
-            raise Exception(msg)
-        if (target_path / INSTALLING_MARKER_FILE).is_file():
-            # Detected installation that was not completed.
-            return False
-        try:
-            node_version = str(self.resolve_version())
-            stored_node_version = (target_path / NODE_VERSION_MARKER_FILE).read_text(encoding='utf-8').strip()
-            if node_version != stored_node_version:
-                return False
-            dst_package_json = target_path / 'package.json'
-            src_hash = md5(src_package_json.read_bytes()).hexdigest()  # noqa: S324
-            dst_hash = md5(dst_package_json.read_bytes()).hexdigest()  # noqa: S324
-            if src_hash != dst_hash:
-                return False
-        except FileNotFoundError:
-            return False
-        return True
+            raise RuntimeError(msg) from error
 
 
 @final
@@ -194,6 +179,8 @@ class NodeRunnerLocal(NodeRunner):
         self._node_version = node_version
         self._node_dir = self._base_dir / 'node'
         self._resolve_paths()
+        # We know the version so can skip calling into node.
+        self._version = create_version(node_version)
 
     # --- NodeRunner overrides ---------------------------------------------------------------------------------------
 

--- a/lsp_utils/helpers.py
+++ b/lsp_utils/helpers.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from hashlib import md5
 from os import PathLike
-from sublime_lib import ResourcePath
 from typing import Any
 from typing import Callable
 from typing import Tuple
@@ -17,6 +16,7 @@ import threading
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from pathlib import Path
+    from sublime_lib import ResourcePath
 
 StringCallback = Callable[[str], None]
 SemanticVersion = Tuple[int, int, int]

--- a/lsp_utils/helpers.py
+++ b/lsp_utils/helpers.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from hashlib import md5
 from os import PathLike
+from sublime_lib import ResourcePath
 from typing import Any
 from typing import Callable
 from typing import Tuple
@@ -122,3 +124,19 @@ def rmtree_ex(path: str | Path, *, ignore_errors: bool = False) -> None:
 def version_to_string(version: SemanticVersion) -> str:
     """Return a string representation of a version tuple."""
     return '.'.join([str(c) for c in version])
+
+
+def is_hash_equal(resource_path: ResourcePath, filesystem_path: Path, *, ignore_missing_source: bool = False) -> bool:
+    if not resource_path.exists():
+        if ignore_missing_source:
+            return True
+        msg = f'Resource "{resource_path}" does not exist inside the package'
+        raise RuntimeError(msg)
+    if not filesystem_path.exists():
+        return False
+    source_hash = md5(resource_path.read_bytes()).hexdigest()  # noqa: S324
+    try:
+        return source_hash == md5(filesystem_path.read_bytes()).hexdigest()  # noqa: S324
+    except FileNotFoundError:
+        pass
+    return False

--- a/lsp_utils/uv_venv_manager.py
+++ b/lsp_utils/uv_venv_manager.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from .constants import INSTALLING_MARKER_FILE
+from .helpers import is_hash_equal
 from .helpers import rmtree_ex
 from .uv_runner import UvRunner
-from hashlib import md5
 from os import pathsep
 from typing import final
 from typing import TYPE_CHECKING
@@ -19,20 +19,6 @@ __all__ = ['UvVenvManager']
 
 PYPROJECT_TOML = 'pyproject.toml'
 UV_LOCK = 'uv.lock'
-
-
-def is_hash_equal(resource_path: ResourcePath, filesystem_path: Path) -> bool:
-    if not resource_path.exists():
-        # If source resource doesn't exist then return "equal" since we don't care about that file then.
-        return True
-    if not filesystem_path.exists():
-        return False
-    source_hash = md5(resource_path.read_bytes()).hexdigest()  # noqa: S324
-    try:
-        return source_hash == md5(filesystem_path.read_bytes()).hexdigest()  # noqa: S324
-    except FileNotFoundError:
-        pass
-    return False
 
 
 @final
@@ -112,7 +98,7 @@ class UvVenvManager:
             not installation_marker_file_path.is_file()
             and self.venv_path.exists()
             and is_hash_equal(source_pyproject_path, target_pyproject_path)
-            and is_hash_equal(source_uv_lock_path, target_uv_lock_path)
+            and is_hash_equal(source_uv_lock_path, target_uv_lock_path, ignore_missing_source=True)
             and (
                 (self.venv_bin_path / self._server_binary_name).is_file()
                 or (self.venv_bin_path / f'{self._server_binary_name}.exe').is_file()


### PR DESCRIPTION
Optimization to avoid calling `node --version` when using `local` node instance. In that case we know the version up-front so don't need to run the node process.