### PR TITLE
workaround PC not picking up latest LSP update

### DIFF
--- a/lsp_utils/_node/node_manager.py
+++ b/lsp_utils/_node/node_manager.py
@@ -62,7 +62,12 @@ class NodeManager:
         """
         package_name = plugin_storage_path.name
         node_runner = NodeManager.resolve(package_name, node_version_requirement)
-        server_path = context.configuration.root_settings.get('server_path')
+        if hasattr(context.configuration, 'root_settings'):
+            server_path = context.configuration.root_settings.get('server_path')
+        elif hasattr(context.configuration, 'server_path'):
+            server_path = context.configuration.server_path
+        else:
+            server_path = 'auto'
         destination_server_directory = None
         if not server_path or server_path == 'auto':
             destination_server_directory = plugin_storage_path / server_directory_resource_path.name


### PR DESCRIPTION
PC has picked up update for this dependency but not normal packages so state got out of sync and broke.

Workaround by falling back if `root_settings` are not available.